### PR TITLE
Feat: Add base MQTT support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ferredge-core",
+ "ferredge-runtime-async-std",
+ "ferredge-runtime-embassy",
+ "ferredge-runtime-tokio",
  "httparse",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +28,101 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ferredge-core"
@@ -36,10 +143,188 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferredge-proto-mqtt"
+version = "0.1.0"
+dependencies = [
+ "ferredge-core",
+ "mqtt-protocol-core",
+ "serde",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mqtt-protocol-core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff175d3d5d1354d0809e3954eb0679628629c8360174980ab00a138923a96a9"
+dependencies = [
+ "arrayvec",
+ "delegate",
+ "derive_builder",
+ "enum_dispatch",
+ "foldhash",
+ "getset",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "num-traits",
+ "num_enum",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -58,6 +343,12 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -90,6 +381,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +429,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +354,7 @@ name = "ferredge-core"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "hashbrown 0.17.0",
  "serde",
 ]
 
@@ -499,6 +506,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ name = "ferredge-proto-mqtt"
 version = "0.1.0"
 dependencies = [
  "ferredge-core",
+ "ferredge-proto-http",
  "ferredge-runtime-async-std",
  "ferredge-runtime-embassy",
  "ferredge-runtime-tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +158,52 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
@@ -50,7 +226,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -61,7 +237,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -72,7 +248,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -93,7 +269,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -103,7 +279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -115,7 +291,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -123,6 +299,49 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ferredge-core"
@@ -147,8 +366,34 @@ name = "ferredge-proto-mqtt"
 version = "0.1.0"
 dependencies = [
  "ferredge-core",
+ "ferredge-runtime-async-std",
+ "ferredge-runtime-embassy",
+ "ferredge-runtime-tokio",
  "mqtt-protocol-core",
  "serde",
+]
+
+[[package]]
+name = "ferredge-runtime-async-std"
+version = "0.1.0"
+dependencies = [
+ "async-std",
+ "ferredge-core",
+]
+
+[[package]]
+name = "ferredge-runtime-embassy"
+version = "0.1.0"
+dependencies = [
+ "ferredge-core",
+]
+
+[[package]]
+name = "ferredge-runtime-tokio"
+version = "0.1.0"
+dependencies = [
+ "ferredge-core",
+ "tokio",
 ]
 
 [[package]]
@@ -164,6 +409,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,7 +469,19 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -192,6 +501,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "httparse"
@@ -222,10 +537,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "mqtt-protocol-core"
@@ -280,7 +648,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -290,10 +658,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -323,7 +728,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -342,6 +747,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -377,7 +795,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -391,6 +809,22 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -414,7 +848,18 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -445,7 +890,21 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "tokio"
+version = "1.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -502,6 +961,88 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/ferredge/ferredge"
-rust-version = "1.85"
+rust-version = "1.93"
 
 [workspace.dependencies]
 # Internal crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ tracing-subscriber = "0.3"
 # Error handling
 thiserror = "2"
 anyhow = "1"
-mqtt_protocol_core = { package = "mqtt-protocol-core", version = "0.7.7", default-features = false }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Unique identifiers
 uuid = { version = "1", features = ["v4", "serde"] }
+
+# Runtimes
 tokio = { version = "1", features = ["rt-multi-thread", "time", "net", "sync", "io-util"] }
 async-std = { version = "1", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ members = [
     "crates/ferredge-core",
     "crates/ferredge-proto-http",
     "crates/ferredge-proto-mqtt",
+    "crates/ferredge-runtime-tokio",
+    "crates/ferredge-runtime-async-std",
+    "crates/ferredge-runtime-embassy",
 ]
 
 [workspace.package]
@@ -18,6 +21,9 @@ rust-version = "1.93"
 ferredge-core = { path = "crates/ferredge-core" }
 ferredge-proto-http = { path = "crates/ferredge-proto-http" }
 ferredge-proto-mqtt = { path = "crates/ferredge-proto-mqtt" }
+ferredge-runtime-tokio = { path = "crates/ferredge-runtime-tokio" }
+ferredge-runtime-async-std = { path = "crates/ferredge-runtime-async-std" }
+ferredge-runtime-embassy = { path = "crates/ferredge-runtime-embassy" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -36,3 +42,5 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Unique identifiers
 uuid = { version = "1", features = ["v4", "serde"] }
+tokio = { version = "1", features = ["rt-multi-thread", "time", "net", "sync", "io-util"] }
+async-std = { version = "1", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/ferredge-core",
     "crates/ferredge-proto-http",
+    "crates/ferredge-proto-mqtt",
 ]
 
 [workspace.package]
@@ -16,6 +17,7 @@ rust-version = "1.93"
 # Internal crates
 ferredge-core = { path = "crates/ferredge-core" }
 ferredge-proto-http = { path = "crates/ferredge-proto-http" }
+ferredge-proto-mqtt = { path = "crates/ferredge-proto-mqtt" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -27,6 +29,7 @@ tracing-subscriber = "0.3"
 # Error handling
 thiserror = "2"
 anyhow = "1"
+mqtt_protocol_core = { package = "mqtt-protocol-core", version = "0.7.7", default-features = false }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/ferredge-core/Cargo.toml
+++ b/crates/ferredge-core/Cargo.toml
@@ -9,9 +9,11 @@ rust-version.workspace = true
 
 [features]
 std = ["serde/std", "bitflags/std"]
+hashbrown = ["dep:hashbrown"]
 
 [dependencies]
 serde = { workspace = true }
 bitflags = { version = "2.10.0", features = ["serde"] }
+hashbrown = { version = "0.17", optional = true }
 
 [dev-dependencies]

--- a/crates/ferredge-core/src/bridge.rs
+++ b/crates/ferredge-core/src/bridge.rs
@@ -1,14 +1,46 @@
-use crate::{ command::Command, device::DeviceProtocol};
+use crate::{
+    command::Command,
+    routed::{RoutedEvent, RoutedMessage, RoutedResult},
+};
 
+/// Emits routed actions produced by bridge logic without requiring allocation.
+pub trait ActionEmitter {
+    /// Error returned if consumer cannot accept one emitted action.
+    type Error;
+
+    /// Emits one routed action produced by bridge evaluation.
+    fn emit(&mut self, action: RoutedMessage) -> Result<(), Self::Error>;
+}
+
+/// Translates routed commands, events, and results across protocol boundaries.
 pub trait ProtocolBridge: Send + Sync {
-    /// Translate a command from source protocol to target protocol
-    fn translate_command(
-        &self,
-        command: Command,
-        source_protocol: DeviceProtocol,
-        target_protocol: DeviceProtocol,
-    ) -> impl Future<Output = Result<Command, String>> + Send;
+    /// Bridge-specific translation error.
+    type Error;
 
-    /// Check if translation between protocols is supported
-    fn supports_translation(&self, from: &DeviceProtocol, to: &DeviceProtocol) -> bool;
+    /// Translates one routed command into zero or more routed actions.
+    fn bridge_command<E>(
+        &self,
+        command: &Command,
+        emitter: &mut E,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        E: ActionEmitter + Send;
+
+    /// Translates one routed event into zero or more routed actions.
+    fn bridge_event<E>(
+        &self,
+        event: &RoutedEvent,
+        emitter: &mut E,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        E: ActionEmitter + Send;
+
+    /// Translates one routed result into zero or more routed actions.
+    fn bridge_result<E>(
+        &self,
+        result: &RoutedResult,
+        emitter: &mut E,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        E: ActionEmitter + Send;
 }

--- a/crates/ferredge-core/src/command.rs
+++ b/crates/ferredge-core/src/command.rs
@@ -1,29 +1,170 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
 use crate::device::DeviceId;
 use serde::{Deserialize, Serialize};
 
+/// Unique identifier for command lifecycle and correlation.
 pub type CommandId = String;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum CommandType {
-    Get,
-    Set,
-    Execute,
+/// High-level lifecycle state for command delivery and completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeliveryState {
+    /// Transport accepted command for further processing.
+    Accepted,
+    /// Router or transport dispatched command to target.
+    Dispatched,
+    /// Command completed successfully and may carry payload.
+    Completed,
+    /// Command failed and should carry error details.
+    Rejected,
+    /// Command expired before completion.
+    TimedOut,
 }
 
-/// Represents a command sent to a device or the core.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Correlates async replies or completion events with original request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Correlation {
+    /// Identifier of original command or request.
+    pub request_id: CommandId,
+    /// Optional logical reply destination such as topic or resource.
+    pub reply_to: Option<Address>,
+}
+
+/// Protocol-neutral logical address used by routed messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Address {
+    /// Resource-oriented address such as HTTP path or Modbus register alias.
+    Resource(String),
+    /// Channel-oriented address such as MQTT or NATS topic.
+    Channel(String),
+}
+
+/// Common delivery guarantees shared by broker-style protocols.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeliveryGuarantee {
+    /// Delivery may be dropped without retry.
+    BestEffort,
+    /// Delivery must be retried until receiver gets at least one copy.
+    AtLeastOnce,
+    /// Delivery must arrive exactly once when transport supports it.
+    ExactlyOnce,
+}
+
+/// Protocol-neutral broker send options preserved in routed command layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BrokerMessageOptions {
+    /// Optional delivery guarantee requested by caller.
+    pub delivery: Option<DeliveryGuarantee>,
+    /// Optional message headers or attributes.
+    pub headers: Vec<(String, String)>,
+    /// Optional logical reply channel.
+    pub reply_to: Option<String>,
+    /// Optional application-level correlation identifier.
+    pub correlation_id: Option<String>,
+}
+
+/// Protocol-neutral broker subscription options preserved in routed command layer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct BrokerSubscriptionOptions {
+    /// Optional delivery guarantee preference for consumed messages.
+    pub delivery: Option<DeliveryGuarantee>,
+    /// Optional durable consumer or subscription name.
+    pub durable_name: Option<String>,
+    /// Optional shared consumer group identifier.
+    pub shared_group: Option<String>,
+}
+
+/// Generic broker address used across topic, queue, subject, and stream transports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerAddress {
+    /// Broker-specific destination or subscription name.
+    pub name: String,
+    /// Optional semantic classification of broker address.
+    pub kind: Option<BrokerChannelKind>,
+}
+
+/// Common broker channel categories used by transport-neutral routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BrokerChannelKind {
+    /// Topic-like fan-out destination.
+    Topic,
+    /// Queue-like work distribution destination.
+    Queue,
+    /// Subject-like routed destination.
+    Subject,
+    /// Stream or log-like destination.
+    Stream,
+}
+
+/// Protocol-neutral operation intent routed between adapters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Intent {
+    /// Reads current state from named resource.
+    Read {
+        resource: String,
+    },
+    /// Writes payload bytes to named resource.
+    Write {
+        resource: String,
+        payload: Vec<u8>,
+    },
+    /// Invokes operation with optional argument payload.
+    Invoke {
+        operation: String,
+        args: Option<Vec<u8>>,
+    },
+    /// Sends payload to broker-oriented channel such as topic, subject, queue, or stream.
+    Send {
+        channel: BrokerAddress,
+        payload: Vec<u8>,
+        options: BrokerMessageOptions,
+    },
+    /// Subscribes to broker-oriented channel such as topic, subject, queue, or stream.
+    Subscribe {
+        channel: BrokerAddress,
+        options: BrokerSubscriptionOptions,
+    },
+    /// Removes prior subscription for channel.
+    Unsubscribe {
+        channel: BrokerAddress,
+    },
+}
+
+/// Represents a protocol-neutral command sent to a device or the core.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Command {
+    /// Stable command identifier.
     pub id: CommandId,
+    /// Optional origin device when command was emitted by another device.
+    pub source_device_id: Option<DeviceId>,
+    /// Destination device identifier.
     pub target_device_id: DeviceId,
-    pub command_type: CommandType,
-    pub resource: String,
-    pub payload: Option<Vec<u8>>,
+    /// Requested protocol-neutral operation.
+    pub intent: Intent,
+    /// Optional async reply or completion correlation metadata.
+    pub correlation: Option<Correlation>,
 }
 
-/// Represents the result of a command execution.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Represents the result of command execution or delivery.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CommandResult {
+    /// Identifier of command this result belongs to.
     pub command_id: CommandId,
+    /// Device that produced this result.
     pub device_id: DeviceId,
-    pub res: Result<Option<Vec<u8>>, String>,
+    /// Delivery or completion state.
+    pub state: DeliveryState,
+    /// Optional payload returned by successful completion.
+    pub payload: Option<Vec<u8>>,
+    /// Optional human-readable error description.
+    pub error: Option<String>,
+    /// Optional correlation metadata preserved from originating command.
+    pub correlation: Option<Correlation>,
 }

--- a/crates/ferredge-core/src/command.rs
+++ b/crates/ferredge-core/src/command.rs
@@ -1,10 +1,5 @@
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-use std::{string::String, vec::Vec};
-
-#[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
 
 use crate::device::DeviceId;
@@ -57,6 +52,26 @@ pub enum DeliveryGuarantee {
     ExactlyOnce,
 }
 
+/// MQTT payload format indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MqttPayloadFormat {
+    /// Payload is arbitrary binary bytes.
+    Bytes,
+    /// Payload should be interpreted as UTF-8 text.
+    Utf8,
+}
+
+/// MQTT retained-message handling policy for subscriptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MqttRetainHandling {
+    /// Send retained messages when subscription is established.
+    SendRetained,
+    /// Send retained messages only when subscription does not already exist.
+    SendRetainedIfNotExists,
+    /// Do not send retained messages on subscribe.
+    DoNotSendRetained,
+}
+
 /// Protocol-neutral broker send options preserved in routed command layer.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct BrokerMessageOptions {
@@ -68,6 +83,8 @@ pub struct BrokerMessageOptions {
     pub reply_to: Option<String>,
     /// Optional application-level correlation identifier.
     pub correlation_id: Option<String>,
+    /// Optional protocol-specific broker extension.
+    pub protocol: Option<BrokerMessageProtocolOptions>,
 }
 
 /// Protocol-neutral broker subscription options preserved in routed command layer.
@@ -79,6 +96,58 @@ pub struct BrokerSubscriptionOptions {
     pub durable_name: Option<String>,
     /// Optional shared consumer group identifier.
     pub shared_group: Option<String>,
+    /// Optional protocol-specific subscription extension.
+    pub protocol: Option<BrokerSubscriptionProtocolOptions>,
+}
+
+/// Tagged protocol-specific broker send options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BrokerMessageProtocolOptions {
+    /// MQTT-specific publish options.
+    Mqtt(MqttMessageOptions),
+}
+
+/// MQTT-specific broker send options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttMessageOptions {
+    /// Whether broker should retain message for future subscribers.
+    pub retain: bool,
+    /// Optional MQTT v5 payload format indicator.
+    pub payload_format: Option<MqttPayloadFormat>,
+    /// Optional MQTT v5 content type.
+    pub content_type: Option<String>,
+    /// Optional MQTT v5 message expiry interval in seconds.
+    pub message_expiry_interval_secs: Option<u32>,
+    /// Optional MQTT v5 topic alias.
+    pub topic_alias: Option<u16>,
+    /// Optional MQTT v5 user properties.
+    pub user_properties: Vec<(String, String)>,
+    /// Optional MQTT v5 response topic. If omitted, generic `reply_to` is used when possible.
+    pub response_topic: Option<String>,
+    /// Optional raw MQTT v5 correlation data.
+    pub correlation_data: Option<Vec<u8>>,
+}
+
+/// Tagged protocol-specific broker subscription options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BrokerSubscriptionProtocolOptions {
+    /// MQTT-specific subscribe options.
+    Mqtt(MqttSubscriptionOptions),
+}
+
+/// MQTT-specific broker subscription options.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttSubscriptionOptions {
+    /// Prevent broker from sending messages published by same client.
+    pub no_local: bool,
+    /// Preserve original RETAIN flag on forwarded messages.
+    pub retain_as_published: bool,
+    /// Retained-message delivery policy when subscription starts.
+    pub retain_handling: Option<MqttRetainHandling>,
+    /// Optional MQTT v5 subscription identifier.
+    pub subscription_identifier: Option<u32>,
+    /// Optional MQTT v5 user properties.
+    pub user_properties: Vec<(String, String)>,
 }
 
 /// Generic broker address used across topic, queue, subject, and stream transports.

--- a/crates/ferredge-core/src/command.rs
+++ b/crates/ferredge-core/src/command.rs
@@ -176,14 +176,9 @@ pub enum BrokerChannelKind {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Intent {
     /// Reads current state from named resource.
-    Read {
-        resource: String,
-    },
+    Read { resource: String },
     /// Writes payload bytes to named resource.
-    Write {
-        resource: String,
-        payload: Vec<u8>,
-    },
+    Write { resource: String, payload: Vec<u8> },
     /// Invokes operation with optional argument payload.
     Invoke {
         operation: String,
@@ -201,9 +196,7 @@ pub enum Intent {
         options: BrokerSubscriptionOptions,
     },
     /// Removes prior subscription for channel.
-    Unsubscribe {
-        channel: BrokerAddress,
-    },
+    Unsubscribe { channel: BrokerAddress },
 }
 
 /// Represents a protocol-neutral command sent to a device or the core.

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -125,6 +125,31 @@ pub enum DeviceEndpoint {
 }
 
 impl DeviceEndpoint {
+    /// Creates an HTTP endpoint from dedicated config.
+    pub fn http(config: HttpEndpointConfig) -> Self {
+        Self::Http(config)
+    }
+
+    /// Creates an MQTT endpoint from dedicated config.
+    pub fn mqtt(config: MqttEndpointConfig) -> Self {
+        Self::Mqtt(config)
+    }
+
+    /// Creates a Modbus TCP endpoint from dedicated config.
+    pub fn modbus_tcp(config: ModbusTcpEndpointConfig) -> Self {
+        Self::ModbusTCP(config)
+    }
+
+    /// Creates a Modbus RTU endpoint from dedicated config.
+    pub fn modbus_rtu(config: ModbusRtuEndpointConfig) -> Self {
+        Self::ModbusRTU(config)
+    }
+
+    /// Creates a CoAP endpoint from dedicated config.
+    pub fn coap(config: CoapEndpointConfig) -> Self {
+        Self::CoAP(config)
+    }
+
     /// Returns protocol implied by endpoint variant.
     pub fn protocol(&self) -> DeviceProtocol {
         match self {
@@ -201,4 +226,57 @@ pub struct Device<T: DeviceResourceAttributes> {
     pub resources: Map<String, DeviceResource<T>>,
     /// Broker endpoint descriptors addressable through message-oriented protocols.
     pub message_endpoints: Vec<DeviceMessageEndpoint>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_endpoint_creators_return_expected_protocols() {
+        assert_eq!(
+            DeviceEndpoint::http(HttpEndpointConfig {
+                url: "127.0.0.1:8080".to_string(),
+            })
+            .protocol(),
+            DeviceProtocol::HTTP
+        );
+        assert_eq!(
+            DeviceEndpoint::mqtt(MqttEndpointConfig {
+                broker: "mqtt://broker".to_string(),
+                client_id: "client-1".to_string(),
+                auth: None,
+                tls: None,
+                keepalive_secs: Some(30),
+                clean_start: true,
+                session_expiry_secs: None,
+                topic_prefix: None,
+            })
+            .protocol(),
+            DeviceProtocol::MQTT
+        );
+        assert_eq!(
+            DeviceEndpoint::modbus_tcp(ModbusTcpEndpointConfig {
+                addr: "127.0.0.1".to_string(),
+                port: 502,
+            })
+            .protocol(),
+            DeviceProtocol::Modbus
+        );
+        assert_eq!(
+            DeviceEndpoint::modbus_rtu(ModbusRtuEndpointConfig {
+                port: "/dev/ttyUSB0".to_string(),
+                baudrate: 9600,
+            })
+            .protocol(),
+            DeviceProtocol::Modbus
+        );
+        assert_eq!(
+            DeviceEndpoint::coap(CoapEndpointConfig {
+                url: "coap://127.0.0.1".to_string(),
+            })
+            .protocol(),
+            DeviceProtocol::CoAP
+        );
+    }
 }

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -1,19 +1,27 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[cfg(feature = "std")]
+use std::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap as StdlessMap, string::String, vec::Vec};
+
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
+
+use crate::command::BrokerAddress;
 
 #[cfg(feature = "std")]
 pub use std::collections::HashMap as Map;
 
 #[cfg(not(feature = "std"))]
-pub use alloc::collections::BTreeMap as Map;
+pub type Map<K, V> = StdlessMap<K, V>;
 
-use crate::router::Driver;
-
+/// Stable identifier for registered device.
 pub type DeviceId = String;
 
+/// High-level device liveness and availability state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceStatus {
     Online,
@@ -22,7 +30,8 @@ pub enum DeviceStatus {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Transport protocol supported by device endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceProtocol {
     MQTT,
     HTTP,
@@ -30,62 +39,166 @@ pub enum DeviceProtocol {
     CoAP,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Optional credential set for protocol endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthConfig {
+    /// Username or principal used for authentication.
+    pub username: Option<String>,
+    /// Password or secret associated with username.
+    pub password: Option<String>,
+}
+
+/// TLS material and flags associated with secure protocol endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TlsConfig {
+    /// Whether TLS is enabled for endpoint.
+    pub enabled: bool,
+    /// Optional PEM-encoded CA certificate.
+    pub ca_certificate_pem: Option<String>,
+    /// Optional PEM-encoded client certificate.
+    pub client_certificate_pem: Option<String>,
+    /// Optional PEM-encoded private key for client certificate.
+    pub client_key_pem: Option<String>,
+}
+
+/// MQTT-specific endpoint configuration required for real broker connections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MqttEndpointConfig {
+    /// Broker host or address string.
+    pub broker: String,
+    /// MQTT client identifier.
+    pub client_id: String,
+    /// Optional username/password authentication.
+    pub auth: Option<AuthConfig>,
+    /// Optional TLS configuration.
+    pub tls: Option<TlsConfig>,
+    /// Optional keepalive interval in seconds.
+    pub keepalive_secs: Option<u16>,
+    /// Whether session starts clean on new connection.
+    pub clean_start: bool,
+    /// Optional session expiry interval in seconds.
+    pub session_expiry_secs: Option<u32>,
+    /// Optional default topic prefix or namespace.
+    pub topic_prefix: Option<String>,
+}
+
+/// HTTP-specific endpoint configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HttpEndpointConfig {
+    /// Base URL or host:port target for device.
+    pub url: String,
+}
+
+/// Modbus TCP-specific endpoint configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModbusTcpEndpointConfig {
+    /// Remote device address or hostname.
+    pub addr: String,
+    /// Remote Modbus TCP port.
+    pub port: u16,
+}
+
+/// Modbus RTU-specific endpoint configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModbusRtuEndpointConfig {
+    /// Serial port device path.
+    pub port: String,
+    /// Serial baudrate used for connection.
+    pub baudrate: u32,
+}
+
+/// CoAP-specific endpoint configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoapEndpointConfig {
+    /// Base CoAP URL for device.
+    pub url: String,
+}
+
+/// Concrete connection endpoint for one device transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceEndpoint {
-    Http { url: String },
-    Mqtt { broker: String },
-    ModbusTCP { addr: String, port: u16 },
-    ModbusRTU { port: String, baudrate: u32 },
-    CoAP { url: String },
+    Http(HttpEndpointConfig),
+    Mqtt(MqttEndpointConfig),
+    ModbusTCP(ModbusTcpEndpointConfig),
+    ModbusRTU(ModbusRtuEndpointConfig),
+    CoAP(CoapEndpointConfig),
 }
 
 impl DeviceEndpoint {
+    /// Returns protocol implied by endpoint variant.
     pub fn protocol(&self) -> DeviceProtocol {
         match self {
-            DeviceEndpoint::Http { .. } => DeviceProtocol::HTTP,
-            DeviceEndpoint::Mqtt { .. } => DeviceProtocol::MQTT,
-            DeviceEndpoint::ModbusTCP { .. } => DeviceProtocol::Modbus,
-            DeviceEndpoint::ModbusRTU { .. } => DeviceProtocol::Modbus,
-            DeviceEndpoint::CoAP { .. } => DeviceProtocol::CoAP,
+            DeviceEndpoint::Http(_) => DeviceProtocol::HTTP,
+            DeviceEndpoint::Mqtt(_) => DeviceProtocol::MQTT,
+            DeviceEndpoint::ModbusTCP(_) => DeviceProtocol::Modbus,
+            DeviceEndpoint::ModbusRTU(_) => DeviceProtocol::Modbus,
+            DeviceEndpoint::CoAP(_) => DeviceProtocol::CoAP,
         }
     }
 }
 
-// marker trait for device resource types
-pub trait DeviceResourceAttributes: for<'de> Deserialize<'de> + Serialize {}
+/// Marker trait for protocol-specific device resource metadata.
+pub trait DeviceResourceAttributes: Clone + core::fmt::Debug + for<'de> Deserialize<'de> + Serialize {}
 
 bitflags! {
+    /// Allowed operations for device resource or channel descriptors.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
     pub struct DeviceResourceAccessPermission: u8 {
-        const READ    = 0b0000_0001;
-        const WRITE   = 0b0000_0010;
-        const EXECUTE = 0b0000_0100;
+        const READ      = 0b0000_0001;
+        const WRITE     = 0b0000_0010;
+        const EXECUTE   = 0b0000_0100;
+        const PUBLISH   = 0b0000_1000;
+        const SUBSCRIBE = 0b0001_0000;
     }
 }
 
+/// Protocol-specific resource descriptor attached to one device.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = "T: DeviceResourceAttributes"))]
 pub struct DeviceResource<T>
 where
     T: DeviceResourceAttributes,
 {
+    /// Human-readable resource name.
     pub name: String,
+    /// Protocol-specific resource metadata.
     pub resource_attributes: T,
+    /// Optional engineering unit for resource value.
     pub unit: Option<String>,
+    /// Optional allowed operations for this resource.
+    pub permission: Option<DeviceResourceAccessPermission>,
+}
+
+/// Broker-oriented destination or subscription descriptor attached to one device.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceMessageEndpoint {
+    /// Human-readable endpoint name.
+    pub name: String,
+    /// Concrete broker address such as topic, queue, subject, or stream.
+    pub address: BrokerAddress,
+    /// Optional transport-agnostic broker metadata entries.
+    pub metadata: Option<Map<String, String>>,
+    /// Optional allowed operations for this broker endpoint.
     pub permission: Option<DeviceResourceAccessPermission>,
 }
 
 /// Represents the metadata and state of a connected device.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Device<T: DeviceResourceAttributes> {
+    /// Stable device identifier.
     pub id: DeviceId,
+    /// Human-readable device name.
     pub name: String,
+    /// Current reported device status.
     pub status: DeviceStatus,
+    /// Concrete transport endpoint details.
     pub endpoint: DeviceEndpoint,
-    // Additional metadata can be stored as a generic map or specific struct
-    // depending on future needs.
+    /// Optional free-form metadata entries.
     pub metadata: Option<Map<String, String>>,
-    // max resources the device can handle
+    /// Optional maximum concurrent connections supported by device.
     pub max_connections: Option<u32>,
+    /// Resource descriptors addressable through request/response style protocols.
     pub resources: Map<String, DeviceResource<T>>,
+    /// Broker endpoint descriptors addressable through message-oriented protocols.
+    pub message_endpoints: Vec<DeviceMessageEndpoint>,
 }

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -137,7 +137,10 @@ impl Default for BrokerReconnectConfig {
 impl BrokerReconnectConfig {
     /// Returns whether the given 1-based reconnect attempt is permitted.
     pub fn allows_attempt(&self, attempt: u32) -> bool {
-        self.enabled && self.max_attempts.is_none_or(|max_attempts| attempt <= max_attempts)
+        self.enabled
+            && self
+                .max_attempts
+                .is_none_or(|max_attempts| attempt <= max_attempts)
     }
 
     /// Returns the backoff delay in milliseconds for the given 1-based reconnect attempt.
@@ -273,10 +276,7 @@ impl MqttEndpointConfig {
     /// Preference order is MQTT 5.0 first, then MQTT 3.1.1. If no explicit
     /// versions are configured, MQTT 5.0 is assumed by default.
     pub fn preferred_protocol_version(&self) -> MqttProtocolVersion {
-        if self
-            .supported_versions
-            .contains(&MqttProtocolVersion::V5_0)
-        {
+        if self.supported_versions.contains(&MqttProtocolVersion::V5_0) {
             MqttProtocolVersion::V5_0
         } else if self
             .supported_versions
@@ -375,7 +375,10 @@ impl DeviceEndpoint {
 }
 
 /// Marker trait for protocol-specific device resource metadata.
-pub trait DeviceResourceAttributes: Clone + core::fmt::Debug + for<'de> Deserialize<'de> + Serialize {}
+pub trait DeviceResourceAttributes:
+    Clone + core::fmt::Debug + for<'de> Deserialize<'de> + Serialize
+{
+}
 
 bitflags! {
     /// Allowed operations for device resource or channel descriptors.

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 use std::{string::String, vec::Vec};
 
 #[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap as StdlessMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap as StdlessMap, collections::VecDeque, string::String, vec::Vec};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::command::BrokerAddress;
 
 #[cfg(feature = "std")]
-pub use std::collections::HashMap as Map;
+pub use std::collections::{HashMap as Map, VecDeque};
 
 #[cfg(not(feature = "std"))]
 pub type Map<K, V> = StdlessMap<K, V>;
@@ -85,6 +85,12 @@ pub struct BrokerReconnectConfig {
     pub multiplier: u32,
     /// Optional maximum reconnect attempts before surfacing failure.
     pub max_attempts: Option<u32>,
+    /// Whether broker subscriptions should be replayed after reconnect succeeds.
+    pub replay_subscriptions: bool,
+    /// Whether outbound requests should be queued while reconnect is in progress.
+    pub queue_requests_while_disconnected: bool,
+    /// Maximum number of queued outbound recovery requests retained in memory.
+    pub max_queued_requests: u32,
 }
 
 impl Default for BrokerReconnectConfig {
@@ -96,6 +102,9 @@ impl Default for BrokerReconnectConfig {
             strategy: BrokerBackoffStrategy::Exponential,
             multiplier: 2,
             max_attempts: None,
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 128,
         }
     }
 }
@@ -438,6 +447,9 @@ mod tests {
             strategy: BrokerBackoffStrategy::Exponential,
             multiplier: 3,
             max_attempts: Some(3),
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 16,
         };
 
         assert!(config.allows_attempt(1));

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -80,6 +80,44 @@ pub struct MqttEndpointConfig {
     pub session_expiry_secs: Option<u32>,
     /// Optional default topic prefix or namespace.
     pub topic_prefix: Option<String>,
+    /// MQTT protocol versions supported by broker or deployment policy.
+    pub supported_versions: Vec<MqttProtocolVersion>,
+}
+
+/// MQTT protocol versions supported by core broker configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MqttProtocolVersion {
+    /// MQTT 3.1.1.
+    V3_1_1,
+    /// MQTT 5.0.
+    V5_0,
+}
+
+impl MqttEndpointConfig {
+    /// Returns highest-preference MQTT version available in config.
+    ///
+    /// Preference order is MQTT 5.0 first, then MQTT 3.1.1. If no explicit
+    /// versions are configured, MQTT 5.0 is assumed by default.
+    pub fn preferred_protocol_version(&self) -> MqttProtocolVersion {
+        if self
+            .supported_versions
+            .contains(&MqttProtocolVersion::V5_0)
+        {
+            MqttProtocolVersion::V5_0
+        } else if self
+            .supported_versions
+            .contains(&MqttProtocolVersion::V3_1_1)
+        {
+            MqttProtocolVersion::V3_1_1
+        } else {
+            MqttProtocolVersion::V5_0
+        }
+    }
+
+    /// Returns whether broker config supports requested MQTT protocol version.
+    pub fn supports_protocol_version(&self, version: MqttProtocolVersion) -> bool {
+        self.supported_versions.is_empty() || self.supported_versions.contains(&version)
+    }
 }
 
 /// HTTP-specific endpoint configuration.
@@ -251,6 +289,7 @@ mod tests {
                 clean_start: true,
                 session_expiry_secs: None,
                 topic_prefix: None,
+                supported_versions: vec![MqttProtocolVersion::V5_0, MqttProtocolVersion::V3_1_1],
             })
             .protocol(),
             DeviceProtocol::MQTT
@@ -278,5 +317,42 @@ mod tests {
             .protocol(),
             DeviceProtocol::CoAP
         );
+    }
+
+    #[test]
+    fn mqtt_endpoint_prefers_v5_then_falls_back_to_v3() {
+        let preferred_v5 = MqttEndpointConfig {
+            broker: "mqtt://broker".to_string(),
+            client_id: "client-v5".to_string(),
+            auth: None,
+            tls: None,
+            keepalive_secs: Some(30),
+            clean_start: true,
+            session_expiry_secs: None,
+            topic_prefix: None,
+            supported_versions: vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0],
+        };
+        assert_eq!(
+            preferred_v5.preferred_protocol_version(),
+            MqttProtocolVersion::V5_0
+        );
+
+        let fallback_v3 = MqttEndpointConfig {
+            broker: "mqtt://broker".to_string(),
+            client_id: "client-v3".to_string(),
+            auth: None,
+            tls: None,
+            keepalive_secs: Some(30),
+            clean_start: true,
+            session_expiry_secs: None,
+            topic_prefix: None,
+            supported_versions: vec![MqttProtocolVersion::V3_1_1],
+        };
+        assert_eq!(
+            fallback_v3.preferred_protocol_version(),
+            MqttProtocolVersion::V3_1_1
+        );
+        assert!(fallback_v3.supports_protocol_version(MqttProtocolVersion::V3_1_1));
+        assert!(!fallback_v3.supports_protocol_version(MqttProtocolVersion::V5_0));
     }
 }

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -139,6 +139,66 @@ impl BrokerReconnectConfig {
 }
 
 /// MQTT-specific endpoint configuration required for real broker connections.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttConnectProperties {
+    /// Client receive maximum requested during CONNECT.
+    pub receive_maximum: Option<u16>,
+    /// Maximum packet size client is willing to receive.
+    pub maximum_packet_size: Option<u32>,
+    /// Maximum topic alias value client supports for inbound traffic.
+    pub topic_alias_maximum: Option<u16>,
+    /// Whether broker should include response information in CONNACK when available.
+    pub request_response_information: Option<bool>,
+    /// Whether broker should include detailed problem information on failures.
+    pub request_problem_information: Option<bool>,
+    /// Optional enhanced authentication method.
+    pub authentication_method: Option<String>,
+    /// Optional enhanced authentication payload.
+    pub authentication_data: Option<Vec<u8>>,
+    /// Optional MQTT v5 user properties attached to CONNECT.
+    pub user_properties: Vec<(String, String)>,
+}
+
+/// Negotiated broker capabilities and identifiers learned from CONNACK.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttConnackProperties {
+    /// Whether broker resumed an existing session.
+    pub session_present: bool,
+    /// MQTT v5 connect reason code returned by broker.
+    pub reason_code: Option<String>,
+    /// Broker-assigned client identifier, if one was returned.
+    pub assigned_client_identifier: Option<String>,
+    /// Response information string returned by broker when requested.
+    pub response_information: Option<String>,
+    /// Alternate server hint returned by broker.
+    pub server_reference: Option<String>,
+    /// Server-advertised receive maximum.
+    pub receive_maximum: Option<u16>,
+    /// Server-advertised maximum packet size.
+    pub maximum_packet_size: Option<u32>,
+    /// Server-advertised topic alias maximum.
+    pub topic_alias_maximum: Option<u16>,
+    /// Maximum QoS supported by server.
+    pub maximum_qos: Option<u8>,
+    /// Whether retained messages are supported by server.
+    pub retain_available: Option<bool>,
+    /// Server-requested keepalive interval override.
+    pub server_keep_alive: Option<u16>,
+    /// Whether wildcard subscriptions are supported by server.
+    pub wildcard_subscription_available: Option<bool>,
+    /// Whether subscription identifiers are supported by server.
+    pub subscription_identifier_available: Option<bool>,
+    /// Whether shared subscriptions are supported by server.
+    pub shared_subscription_available: Option<bool>,
+    /// Optional enhanced authentication method selected by broker.
+    pub authentication_method: Option<String>,
+    /// Optional enhanced authentication data returned by broker.
+    pub authentication_data: Option<Vec<u8>>,
+    /// MQTT v5 user properties returned on CONNACK.
+    pub user_properties: Vec<(String, String)>,
+}
+
+/// MQTT-specific endpoint configuration required for real broker connections.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MqttEndpointConfig {
     /// Broker host or address string.
@@ -157,6 +217,8 @@ pub struct MqttEndpointConfig {
     pub session_expiry_secs: Option<u32>,
     /// Optional default topic prefix or namespace.
     pub topic_prefix: Option<String>,
+    /// Optional MQTT v5 CONNECT property set used during negotiation.
+    pub connect_properties: MqttConnectProperties,
     /// Reconnect policy shared with broker-oriented transports.
     pub reconnect: BrokerReconnectConfig,
     /// MQTT protocol versions supported by broker or deployment policy.
@@ -368,6 +430,7 @@ mod tests {
                 clean_start: true,
                 session_expiry_secs: None,
                 topic_prefix: None,
+                connect_properties: MqttConnectProperties::default(),
                 reconnect: BrokerReconnectConfig::default(),
                 supported_versions: vec![MqttProtocolVersion::V5_0, MqttProtocolVersion::V3_1_1],
             })
@@ -410,6 +473,7 @@ mod tests {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0],
         };
@@ -427,6 +491,7 @@ mod tests {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1],
         };

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -1,11 +1,6 @@
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-use std::{string::String, vec::Vec};
-
-#[cfg(not(feature = "std"))]
-use alloc::{collections::BTreeMap as StdlessMap, collections::VecDeque, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
@@ -15,8 +10,11 @@ use crate::command::BrokerAddress;
 #[cfg(feature = "std")]
 pub use std::collections::{HashMap as Map, VecDeque};
 
-#[cfg(not(feature = "std"))]
-pub type Map<K, V> = StdlessMap<K, V>;
+#[cfg(feature = "hashbrown")]
+pub use hashbrown::collections::{HashMap as Map, VecDeque};
+
+#[cfg(not(any(feature = "std", feature = "hashbrown")))]
+pub use alloc::collections::{BTreeMap as Map, VecDeque};
 
 /// Stable identifier for registered device.
 pub type DeviceId = String;
@@ -59,6 +57,33 @@ pub struct TlsConfig {
     pub client_certificate_pem: Option<String>,
     /// Optional PEM-encoded private key for client certificate.
     pub client_key_pem: Option<String>,
+}
+
+/// MQTT last-will publish configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttWillConfig {
+    /// Topic where broker publishes will on unexpected disconnect.
+    pub topic: String,
+    /// Will payload bytes.
+    pub payload: Vec<u8>,
+    /// Delivery guarantee used for will publish.
+    pub delivery: Option<crate::command::DeliveryGuarantee>,
+    /// Whether will should be retained by broker.
+    pub retain: bool,
+    /// Optional MQTT v5 will delay interval in seconds.
+    pub delay_interval_secs: Option<u32>,
+    /// Optional MQTT v5 will payload format indicator.
+    pub payload_format: Option<crate::command::MqttPayloadFormat>,
+    /// Optional MQTT v5 will message expiry interval in seconds.
+    pub message_expiry_interval_secs: Option<u32>,
+    /// Optional MQTT v5 will content type.
+    pub content_type: Option<String>,
+    /// Optional MQTT v5 will response topic.
+    pub response_topic: Option<String>,
+    /// Optional MQTT v5 will correlation data.
+    pub correlation_data: Option<Vec<u8>>,
+    /// Optional MQTT v5 will user properties.
+    pub user_properties: Vec<(String, String)>,
 }
 
 /// Strategy used to compute delay between broker reconnect attempts.
@@ -151,6 +176,8 @@ pub struct MqttConnectProperties {
     pub request_response_information: Option<bool>,
     /// Whether broker should include detailed problem information on failures.
     pub request_problem_information: Option<bool>,
+    /// Optional session expiry interval override in seconds.
+    pub session_expiry_interval_secs: Option<u32>,
     /// Optional enhanced authentication method.
     pub authentication_method: Option<String>,
     /// Optional enhanced authentication payload.
@@ -166,6 +193,8 @@ pub struct MqttConnackProperties {
     pub session_present: bool,
     /// MQTT v5 connect reason code returned by broker.
     pub reason_code: Option<String>,
+    /// Optional human-readable connect reason string.
+    pub reason_string: Option<String>,
     /// Broker-assigned client identifier, if one was returned.
     pub assigned_client_identifier: Option<String>,
     /// Response information string returned by broker when requested.
@@ -178,6 +207,8 @@ pub struct MqttConnackProperties {
     pub maximum_packet_size: Option<u32>,
     /// Server-advertised topic alias maximum.
     pub topic_alias_maximum: Option<u16>,
+    /// Session expiry interval negotiated by broker.
+    pub session_expiry_interval_secs: Option<u32>,
     /// Maximum QoS supported by server.
     pub maximum_qos: Option<u8>,
     /// Whether retained messages are supported by server.
@@ -219,6 +250,8 @@ pub struct MqttEndpointConfig {
     pub topic_prefix: Option<String>,
     /// Optional MQTT v5 CONNECT property set used during negotiation.
     pub connect_properties: MqttConnectProperties,
+    /// Optional MQTT last-will configuration.
+    pub will: Option<MqttWillConfig>,
     /// Reconnect policy shared with broker-oriented transports.
     pub reconnect: BrokerReconnectConfig,
     /// MQTT protocol versions supported by broker or deployment policy.
@@ -430,6 +463,7 @@ mod tests {
                 clean_start: true,
                 session_expiry_secs: None,
                 topic_prefix: None,
+                will: None,
                 connect_properties: MqttConnectProperties::default(),
                 reconnect: BrokerReconnectConfig::default(),
                 supported_versions: vec![MqttProtocolVersion::V5_0, MqttProtocolVersion::V3_1_1],
@@ -476,6 +510,7 @@ mod tests {
             connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0],
+            will: None,
         };
         assert_eq!(
             preferred_v5.preferred_protocol_version(),
@@ -494,6 +529,7 @@ mod tests {
             connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1],
+            will: None,
         };
         assert_eq!(
             fallback_v3.preferred_protocol_version(),

--- a/crates/ferredge-core/src/device.rs
+++ b/crates/ferredge-core/src/device.rs
@@ -61,6 +61,74 @@ pub struct TlsConfig {
     pub client_key_pem: Option<String>,
 }
 
+/// Strategy used to compute delay between broker reconnect attempts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BrokerBackoffStrategy {
+    /// Use the same delay for every reconnect attempt.
+    Fixed,
+    /// Multiply the delay by `multiplier` for each later attempt, capped by `max_delay_ms`.
+    Exponential,
+}
+
+/// Shared reconnect policy for broker-oriented transports.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BrokerReconnectConfig {
+    /// Whether automatic reconnect attempts are enabled.
+    pub enabled: bool,
+    /// Delay before the first reconnect attempt in milliseconds.
+    pub initial_delay_ms: u64,
+    /// Maximum delay between reconnect attempts in milliseconds.
+    pub max_delay_ms: u64,
+    /// Backoff strategy used to compute retry delay.
+    pub strategy: BrokerBackoffStrategy,
+    /// Multiplier used by exponential backoff. Ignored for fixed backoff.
+    pub multiplier: u32,
+    /// Optional maximum reconnect attempts before surfacing failure.
+    pub max_attempts: Option<u32>,
+}
+
+impl Default for BrokerReconnectConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            initial_delay_ms: 250,
+            max_delay_ms: 5_000,
+            strategy: BrokerBackoffStrategy::Exponential,
+            multiplier: 2,
+            max_attempts: None,
+        }
+    }
+}
+
+impl BrokerReconnectConfig {
+    /// Returns whether the given 1-based reconnect attempt is permitted.
+    pub fn allows_attempt(&self, attempt: u32) -> bool {
+        self.enabled && self.max_attempts.is_none_or(|max_attempts| attempt <= max_attempts)
+    }
+
+    /// Returns the backoff delay in milliseconds for the given 1-based reconnect attempt.
+    pub fn delay_ms_for_attempt(&self, attempt: u32) -> u64 {
+        if attempt <= 1 {
+            return self.initial_delay_ms.min(self.max_delay_ms);
+        }
+
+        match self.strategy {
+            BrokerBackoffStrategy::Fixed => self.initial_delay_ms.min(self.max_delay_ms),
+            BrokerBackoffStrategy::Exponential => {
+                let multiplier = u64::from(self.multiplier.max(1));
+                let mut delay = self.initial_delay_ms.max(1);
+                for _ in 1..attempt {
+                    delay = delay.saturating_mul(multiplier);
+                    if delay >= self.max_delay_ms {
+                        return self.max_delay_ms;
+                    }
+                }
+                delay.min(self.max_delay_ms)
+            }
+        }
+    }
+}
+
 /// MQTT-specific endpoint configuration required for real broker connections.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MqttEndpointConfig {
@@ -80,6 +148,8 @@ pub struct MqttEndpointConfig {
     pub session_expiry_secs: Option<u32>,
     /// Optional default topic prefix or namespace.
     pub topic_prefix: Option<String>,
+    /// Reconnect policy shared with broker-oriented transports.
+    pub reconnect: BrokerReconnectConfig,
     /// MQTT protocol versions supported by broker or deployment policy.
     pub supported_versions: Vec<MqttProtocolVersion>,
 }
@@ -289,6 +359,7 @@ mod tests {
                 clean_start: true,
                 session_expiry_secs: None,
                 topic_prefix: None,
+                reconnect: BrokerReconnectConfig::default(),
                 supported_versions: vec![MqttProtocolVersion::V5_0, MqttProtocolVersion::V3_1_1],
             })
             .protocol(),
@@ -330,6 +401,7 @@ mod tests {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0],
         };
         assert_eq!(
@@ -346,6 +418,7 @@ mod tests {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V3_1_1],
         };
         assert_eq!(
@@ -354,5 +427,25 @@ mod tests {
         );
         assert!(fallback_v3.supports_protocol_version(MqttProtocolVersion::V3_1_1));
         assert!(!fallback_v3.supports_protocol_version(MqttProtocolVersion::V5_0));
+    }
+
+    #[test]
+    fn broker_reconnect_backoff_caps_and_respects_attempt_limit() {
+        let config = BrokerReconnectConfig {
+            enabled: true,
+            initial_delay_ms: 100,
+            max_delay_ms: 1_000,
+            strategy: BrokerBackoffStrategy::Exponential,
+            multiplier: 3,
+            max_attempts: Some(3),
+        };
+
+        assert!(config.allows_attempt(1));
+        assert!(config.allows_attempt(3));
+        assert!(!config.allows_attempt(4));
+        assert_eq!(config.delay_ms_for_attempt(1), 100);
+        assert_eq!(config.delay_ms_for_attempt(2), 300);
+        assert_eq!(config.delay_ms_for_attempt(3), 900);
+        assert_eq!(config.delay_ms_for_attempt(4), 1_000);
     }
 }

--- a/crates/ferredge-core/src/lib.rs
+++ b/crates/ferredge-core/src/lib.rs
@@ -5,6 +5,7 @@ mod net;
 mod runtime;
 mod router;
 mod routed;
+mod sync;
 
 pub mod prelude {
     pub use crate::bridge::*;
@@ -14,4 +15,5 @@ pub mod prelude {
     pub use crate::runtime::*;
     pub use crate::router::*;
     pub use crate::routed::*;
+    pub use crate::sync::*;
 }

--- a/crates/ferredge-core/src/lib.rs
+++ b/crates/ferredge-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod bridge;
 mod command;
 mod device;
+mod runtime;
 mod router;
 mod routed;
 
@@ -8,6 +9,7 @@ pub mod prelude {
     pub use crate::bridge::*;
     pub use crate::command::*;
     pub use crate::device::*;
+    pub use crate::runtime::*;
     pub use crate::router::*;
     pub use crate::routed::*;
 }

--- a/crates/ferredge-core/src/lib.rs
+++ b/crates/ferredge-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod bridge;
 mod command;
 mod device;
+mod net;
 mod runtime;
 mod router;
 mod routed;
@@ -9,6 +10,7 @@ pub mod prelude {
     pub use crate::bridge::*;
     pub use crate::command::*;
     pub use crate::device::*;
+    pub use crate::net::*;
     pub use crate::runtime::*;
     pub use crate::router::*;
     pub use crate::routed::*;

--- a/crates/ferredge-core/src/lib.rs
+++ b/crates/ferredge-core/src/lib.rs
@@ -2,10 +2,12 @@ mod bridge;
 mod command;
 mod device;
 mod router;
+mod routed;
 
 pub mod prelude {
     pub use crate::bridge::*;
     pub use crate::command::*;
     pub use crate::device::*;
     pub use crate::router::*;
+    pub use crate::routed::*;
 }

--- a/crates/ferredge-core/src/lib.rs
+++ b/crates/ferredge-core/src/lib.rs
@@ -2,9 +2,9 @@ mod bridge;
 mod command;
 mod device;
 mod net;
-mod runtime;
-mod router;
 mod routed;
+mod router;
+mod runtime;
 mod sync;
 
 pub mod prelude {
@@ -12,8 +12,8 @@ pub mod prelude {
     pub use crate::command::*;
     pub use crate::device::*;
     pub use crate::net::*;
-    pub use crate::runtime::*;
-    pub use crate::router::*;
     pub use crate::routed::*;
+    pub use crate::router::*;
+    pub use crate::runtime::*;
     pub use crate::sync::*;
 }

--- a/crates/ferredge-core/src/net.rs
+++ b/crates/ferredge-core/src/net.rs
@@ -56,11 +56,10 @@ pub trait AsyncNet: Clone + Send + Sync + 'static {
 
     /// Establishes one outbound byte-stream connection to the given address.
     fn connect(&self, address: &str)
-        -> impl Future<Output = Result<Self::Socket, NetError>> + Send;
+    -> impl Future<Output = Result<Self::Socket, NetError>> + Send;
 
     /// Binds one listener to the given local address when supported.
-    fn bind(&self, address: &str)
-        -> impl Future<Output = Result<Self::Listener, NetError>> + Send;
+    fn bind(&self, address: &str) -> impl Future<Output = Result<Self::Listener, NetError>> + Send;
 }
 
 #[cfg(test)]

--- a/crates/ferredge-core/src/net.rs
+++ b/crates/ferredge-core/src/net.rs
@@ -1,0 +1,181 @@
+use core::future::Future;
+
+/// Error returned by abstract async network operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetError {
+    /// Remote endpoint closed the connection.
+    Closed,
+    /// Operation timed out before completion.
+    TimedOut,
+    /// Address could not be resolved or connected.
+    Unreachable,
+    /// Requested operation is unsupported by this transport.
+    Unsupported,
+    /// Underlying runtime or driver is unavailable.
+    RuntimeUnavailable,
+    /// Transport-specific failure string preserved by adapter.
+    Other(&'static str),
+}
+
+/// Async bidirectional byte stream used by protocol adapters.
+pub trait AsyncSocket: Send + Sync + 'static {
+    /// Reads bytes into the provided buffer and returns the number of bytes read.
+    fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = Result<usize, NetError>> + Send;
+
+    /// Writes bytes from the provided buffer and returns the number of bytes written.
+    fn write(&mut self, buf: &[u8]) -> impl Future<Output = Result<usize, NetError>> + Send;
+
+    /// Flushes buffered outbound bytes when the transport supports it.
+    fn flush(&mut self) -> impl Future<Output = Result<(), NetError>> + Send;
+
+    /// Closes the socket gracefully when the transport supports it.
+    fn close(&mut self) -> impl Future<Output = Result<(), NetError>> + Send;
+}
+
+/// Async listener that accepts inbound sockets.
+pub trait AsyncListener: Send + Sync + 'static {
+    /// Socket type produced by this listener.
+    type Socket: AsyncSocket;
+
+    /// Accepts one inbound connection from the listener.
+    fn accept(&mut self) -> impl Future<Output = Result<Self::Socket, NetError>> + Send;
+
+    /// Closes the listener and releases bound resources.
+    fn close(&mut self) -> impl Future<Output = Result<(), NetError>> + Send;
+}
+
+/// Async network transport factory shared by protocol adapters.
+///
+/// Implementations are intended to bridge concrete ecosystems such as Tokio, async-std,
+/// or embassy-net into a transport-neutral socket model consumed by protocol crates.
+pub trait AsyncNet: Clone + Send + Sync + 'static {
+    /// Connected socket type returned by `connect`.
+    type Socket: AsyncSocket;
+    /// Listener type returned by `bind`.
+    type Listener: AsyncListener<Socket = Self::Socket>;
+
+    /// Establishes one outbound byte-stream connection to the given address.
+    fn connect(&self, address: &str)
+        -> impl Future<Output = Result<Self::Socket, NetError>> + Send;
+
+    /// Binds one listener to the given local address when supported.
+    fn bind(&self, address: &str)
+        -> impl Future<Output = Result<Self::Listener, NetError>> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::{
+        pin::Pin,
+        task::{Context, Poll, Waker},
+    };
+
+    #[derive(Default)]
+    struct MockSocket {
+        read_data: Option<&'static [u8]>,
+        write_count: usize,
+        closed: bool,
+    }
+
+    impl AsyncSocket for MockSocket {
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, NetError> {
+            let Some(read_data) = self.read_data.take() else {
+                return Err(NetError::Closed);
+            };
+            let len = read_data.len().min(buf.len());
+            buf[..len].copy_from_slice(&read_data[..len]);
+            Ok(len)
+        }
+
+        async fn write(&mut self, buf: &[u8]) -> Result<usize, NetError> {
+            self.write_count += buf.len();
+            Ok(buf.len())
+        }
+
+        async fn flush(&mut self) -> Result<(), NetError> {
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<(), NetError> {
+            self.closed = true;
+            Ok(())
+        }
+    }
+
+    struct MockListener {
+        accepted: bool,
+    }
+
+    impl AsyncListener for MockListener {
+        type Socket = MockSocket;
+
+        async fn accept(&mut self) -> Result<Self::Socket, NetError> {
+            if self.accepted {
+                Err(NetError::Closed)
+            } else {
+                self.accepted = true;
+                Ok(MockSocket {
+                    read_data: Some(b"ping"),
+                    write_count: 0,
+                    closed: false,
+                })
+            }
+        }
+
+        async fn close(&mut self) -> Result<(), NetError> {
+            self.accepted = true;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct MockNet;
+
+    impl AsyncNet for MockNet {
+        type Socket = MockSocket;
+        type Listener = MockListener;
+
+        async fn connect(&self, _address: &str) -> Result<Self::Socket, NetError> {
+            Ok(MockSocket {
+                read_data: Some(b"pong"),
+                write_count: 0,
+                closed: false,
+            })
+        }
+
+        async fn bind(&self, _address: &str) -> Result<Self::Listener, NetError> {
+            Ok(MockListener { accepted: false })
+        }
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        let mut future = Pin::from(Box::new(future));
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    #[test]
+    fn mock_async_net_contract_is_usable() {
+        let net = MockNet;
+        let mut socket = block_on(net.connect("example:1883")).expect("connect should succeed");
+        let mut buf = [0u8; 8];
+        let n = block_on(socket.read(&mut buf)).expect("read should succeed");
+        assert_eq!(&buf[..n], b"pong");
+        assert_eq!(block_on(socket.write(b"abc")), Ok(3));
+        assert_eq!(block_on(socket.flush()), Ok(()));
+        assert_eq!(block_on(socket.close()), Ok(()));
+
+        let mut listener = block_on(net.bind("127.0.0.1:0")).expect("bind should succeed");
+        let mut accepted = block_on(listener.accept()).expect("accept should succeed");
+        let n = block_on(accepted.read(&mut buf)).expect("accepted read should succeed");
+        assert_eq!(&buf[..n], b"ping");
+        assert_eq!(block_on(listener.close()), Ok(()));
+    }
+}

--- a/crates/ferredge-core/src/routed.rs
+++ b/crates/ferredge-core/src/routed.rs
@@ -57,6 +57,8 @@ pub struct MqttMeta {
     pub subscription_identifiers: Vec<u32>,
     /// Optional MQTT v5 user properties preserved from packet metadata.
     pub user_properties: Vec<(String, String)>,
+    /// Optional MQTT v5 reason code list for ack or disconnect packets.
+    pub reason_codes: Vec<String>,
 }
 
 /// Transport-specific message metadata preserved during routing.

--- a/crates/ferredge-core/src/routed.rs
+++ b/crates/ferredge-core/src/routed.rs
@@ -1,0 +1,96 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    command::{Address, Command, CommandResult, Correlation},
+    device::{DeviceId, DeviceProtocol},
+};
+
+/// Identifies concrete source or target transport endpoint inside router graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointRef {
+    /// Device identifier registered with router.
+    pub device_id: DeviceId,
+    /// Transport protocol used by device endpoint.
+    pub protocol: DeviceProtocol,
+}
+
+/// Optional HTTP-specific metadata carried alongside routed messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HttpMeta {
+    /// HTTP method used for outbound or inbound message.
+    pub method: Option<String>,
+    /// HTTP path or resource slug associated with message.
+    pub path: Option<String>,
+    /// HTTP response status code when available.
+    pub status_code: Option<u16>,
+}
+
+/// Optional MQTT-specific metadata carried alongside routed messages.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MqttMeta {
+    /// Topic name associated with publish or inbound message.
+    pub topic: String,
+    /// MQTT quality-of-service level.
+    pub qos: u8,
+    /// Whether message was retained by broker.
+    pub retain: bool,
+    /// Whether message had MQTT duplicate delivery flag set.
+    pub duplicate: bool,
+    /// Packet identifier when protocol exchange exposed one.
+    pub packet_id: Option<u16>,
+}
+
+/// Transport-specific message metadata preserved during routing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransportMeta {
+    /// HTTP transport metadata.
+    Http(HttpMeta),
+    /// MQTT transport metadata.
+    Mqtt(MqttMeta),
+}
+
+/// Normalized inbound event emitted by one protocol adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutedEvent {
+    /// Source endpoint that emitted this event.
+    pub source: EndpointRef,
+    /// Logical address targeted by event, such as resource or topic.
+    pub address: Address,
+    /// Opaque event payload bytes preserved across routing.
+    pub payload: Vec<u8>,
+    /// Optional request correlation for reply-topic or async workflows.
+    pub correlation: Option<Correlation>,
+    /// Optional transport metadata preserved from source protocol.
+    pub transport: Option<TransportMeta>,
+}
+
+/// Normalized command result or transport completion emitted by one adapter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RoutedResult {
+    /// Source endpoint that produced this result.
+    pub source: EndpointRef,
+    /// Protocol-neutral command result payload.
+    pub result: CommandResult,
+    /// Optional transport metadata preserved from source protocol.
+    pub transport: Option<TransportMeta>,
+}
+
+/// Unified message envelope accepted by router and bridge layers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum RoutedMessage {
+    /// Routed command envelope.
+    Command(Command),
+    /// Routed event envelope.
+    Event(RoutedEvent),
+    /// Routed result envelope.
+    Result(RoutedResult),
+}

--- a/crates/ferredge-core/src/routed.rs
+++ b/crates/ferredge-core/src/routed.rs
@@ -47,6 +47,16 @@ pub struct MqttMeta {
     pub duplicate: bool,
     /// Packet identifier when protocol exchange exposed one.
     pub packet_id: Option<u16>,
+    /// Optional content type declared on MQTT v5 publish.
+    pub content_type: Option<String>,
+    /// Optional response topic declared on MQTT v5 publish.
+    pub response_topic: Option<String>,
+    /// Optional correlation data preserved as UTF-8 lossless string view.
+    pub correlation_data: Option<String>,
+    /// Optional subscription identifiers included by broker on MQTT v5 publish.
+    pub subscription_identifiers: Vec<u32>,
+    /// Optional MQTT v5 user properties preserved from packet metadata.
+    pub user_properties: Vec<(String, String)>,
 }
 
 /// Transport-specific message metadata preserved during routing.

--- a/crates/ferredge-core/src/routed.rs
+++ b/crates/ferredge-core/src/routed.rs
@@ -49,16 +49,26 @@ pub struct MqttMeta {
     pub packet_id: Option<u16>,
     /// Optional content type declared on MQTT v5 publish.
     pub content_type: Option<String>,
+    /// Optional MQTT v5 payload format indicator.
+    pub payload_format: Option<String>,
+    /// Optional MQTT v5 message expiry interval in seconds.
+    pub message_expiry_interval_secs: Option<u32>,
     /// Optional response topic declared on MQTT v5 publish.
     pub response_topic: Option<String>,
     /// Optional correlation data preserved as UTF-8 lossless string view.
     pub correlation_data: Option<String>,
+    /// Optional raw correlation data preserved losslessly.
+    pub correlation_data_bytes: Option<Vec<u8>>,
+    /// Optional MQTT v5 topic alias.
+    pub topic_alias: Option<u16>,
     /// Optional subscription identifiers included by broker on MQTT v5 publish.
     pub subscription_identifiers: Vec<u32>,
     /// Optional MQTT v5 user properties preserved from packet metadata.
     pub user_properties: Vec<(String, String)>,
     /// Optional MQTT v5 reason code list for ack or disconnect packets.
     pub reason_codes: Vec<String>,
+    /// Optional MQTT v5 human-readable reason string.
+    pub reason_string: Option<String>,
 }
 
 /// Transport-specific message metadata preserved during routing.

--- a/crates/ferredge-core/src/router.rs
+++ b/crates/ferredge-core/src/router.rs
@@ -50,7 +50,10 @@ pub trait EventSource: Send + Sync {
     /// Starts listening and forwards inbound events into provided sink.
     fn start_listening<S>(&self, sink: S) -> impl Future<Output = Result<(), Self::Error>> + Send
     where
-        S: EventSink<Event = Self::Event> + Send;
+        S: EventSink<Event = Self::Event> + Send + 'static;
+
+    /// Stops active listening loop without requiring full driver shutdown.
+    fn stop_listening(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 /// Capability for publish/subscribe protocols such as MQTT.

--- a/crates/ferredge-core/src/router.rs
+++ b/crates/ferredge-core/src/router.rs
@@ -1,56 +1,123 @@
 use crate::command::{Command, CommandResult};
-use crate::device::{Device, DeviceId, DeviceResourceAttributes};
+use crate::device::{Device, DeviceResourceAttributes};
+use crate::routed::{RoutedEvent, RoutedMessage, RoutedResult};
 
-/// A generic message that flows through the system.
-#[derive(Debug, Clone)]
-pub enum Message {
-    Command(Command),
-    Event(DeviceEvent),
-    Response(CommandResult),
+/// Receives protocol-native or routed events emitted by drivers.
+pub trait EventSink: Send {
+    /// Event type accepted by this sink.
+    type Event;
+    /// Error returned when sink processing fails.
+    type Error;
+
+    /// Handles one event emitted from driver ingress.
+    fn handle(&mut self, event: Self::Event) -> Result<(), Self::Error>;
 }
 
-#[derive(Debug, Clone)]
-pub struct DeviceEvent {
-    pub device_id: String,
-    pub timestamp: u64,
-    pub data: Vec<u8>,
+/// Lifecycle hooks shared by all protocol drivers.
+pub trait Lifecycle: Send + Sync {
+    /// Driver-specific startup or shutdown error.
+    type Error;
+
+    /// Starts protocol resources such as connections, polling loops, or subscriptions.
+    fn start(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    /// Stops protocol resources and performs cleanup.
+    fn stop(&self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
-/// The main trait for the Core logic.
-/// It routes messages between the external world (API), Drivers, and Storage.
+/// Capability for request/response style protocols such as HTTP or Modbus.
+pub trait RequestResponse: Send + Sync {
+    /// Native outbound request type understood by concrete driver.
+    type Request;
+    /// Native response type returned by concrete driver.
+    type Response;
+    /// Driver-specific request execution error.
+    type Error;
 
-pub trait Router<T: DeviceResourceAttributes, Dr: Driver>: Send + Sync {
-    /// Register a new device with the core.
-    fn register_device(&self, device: Device<T>) -> impl Future<Output = Result<(), String>> + Send;
+    /// Executes one native request against underlying transport.
+    fn execute(
+        &self,
+        request: Self::Request,
+    ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send;
+}
 
-    /// Route a command to a specific device.
+/// Capability for drivers that can emit unsolicited inbound events.
+pub trait EventSource: Send + Sync {
+    /// Event emitted by protocol ingress.
+    type Event;
+    /// Driver-specific listening error.
+    type Error;
+
+    /// Starts listening and forwards inbound events into provided sink.
+    fn start_listening<S>(&self, sink: S) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        S: EventSink<Event = Self::Event> + Send;
+}
+
+/// Capability for publish/subscribe protocols such as MQTT.
+pub trait PubSub: Send + Sync {
+    /// Native publish request type.
+    type PublishRequest;
+    /// Native subscription descriptor type.
+    type Subscription;
+    /// Driver-specific pub/sub error.
+    type Error;
+
+    /// Publishes one message to transport.
+    fn publish(
+        &self,
+        request: Self::PublishRequest,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Registers one subscription and forwards matching messages into provided sink.
+    fn subscribe<S>(
+        &self,
+        subscription: Self::Subscription,
+        sink: S,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        S: EventSink<Event = RoutedEvent> + Send;
+
+    /// Removes one subscription from transport.
+    fn unsubscribe(
+        &self,
+        subscription: Self::Subscription,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Protocol-neutral router for commands, events, and results.
+pub trait Router: Send + Sync {
+    /// Router-specific error type.
+    type Error;
+
+    /// Registers one device and its metadata with router state.
+    fn register_device<T>(
+        &self,
+        device: Device<T>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send
+    where
+        T: DeviceResourceAttributes;
+
+    /// Routes already-normalized message through router pipeline.
+    fn route_message(
+        &self,
+        message: RoutedMessage,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+
+    /// Routes one command and returns command-level result state.
     fn route_command(
         &self,
         command: Command,
-    ) -> impl Future<Output = Result<CommandResult, String>> + Send;
+    ) -> impl Future<Output = Result<CommandResult, Self::Error>> + Send;
 
-    /// Handle an incoming event from a device (e.g., sensor reading).
-    /// This typically involves routing to storage or triggering other actions.
-    fn handle_event(&self, event: DeviceEvent) -> impl Future<Output = Result<(), String>> + Send;
-
-    /// Route a command from one device to another
-    fn route_device_to_device(
+    /// Handles one routed event emitted from protocol ingress.
+    fn handle_event(
         &self,
-        source_device_id: DeviceId,
-        command: Command,
-    ) -> impl Future<Output = Result<CommandResult, String>> + Send;
-}
+        event: RoutedEvent,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 
-/// Trait for Device Drivers to implement.
-/// The Core uses this to communicate with the actual hardware/protocol.
-pub trait Driver: Send + Sync {
-    /// Execute a command on the hardware.
-    fn execute(&self, command: Command) -> impl Future<Output = CommandResult> + Send;
-
-    /// Start listening for events from the hardware.
-    /// This usually spawns a task that feeds events back to the Core.
-    fn start(&self) -> impl Future<Output = Result<(), String>> + Send;
-
-    /// Stop the driver.
-    fn stop(&self) -> impl Future<Output = Result<(), String>> + Send;
+    /// Handles one routed result or completion update.
+    fn handle_result(
+        &self,
+        result: RoutedResult,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/crates/ferredge-core/src/runtime.rs
+++ b/crates/ferredge-core/src/runtime.rs
@@ -1,0 +1,225 @@
+use core::{future::Future, time::Duration};
+
+/// Error returned by runtime-backed task handles.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskJoinError {
+    /// Task was cancelled or aborted before successful completion.
+    Cancelled,
+    /// Task failed because underlying runtime shut down unexpectedly.
+    RuntimeUnavailable,
+}
+
+/// Error returned by runtime-backed channel operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelError {
+    /// Channel is full and cannot currently accept more messages.
+    Full,
+    /// Channel was closed by the receiver or runtime.
+    Closed,
+    /// Channel operation failed because runtime resources are unavailable.
+    RuntimeUnavailable,
+}
+
+/// Handle returned by runtime task spawning.
+///
+/// Concrete runtimes such as Tokio, async-std, or embassy can map this trait to their own
+/// task-handle concepts while keeping protocol crates generic over the runtime.
+pub trait TaskHandle<T>: Send
+where
+    T: Send + 'static,
+{
+    /// Waits for the task to finish and returns its output or runtime-level failure.
+    fn join(&mut self) -> impl Future<Output = Result<T, TaskJoinError>> + Send;
+
+    /// Requests cancellation of the task when supported by the runtime.
+    fn abort(&self);
+
+    /// Returns whether the task has already completed.
+    fn is_finished(&self) -> bool;
+}
+
+/// Async sender half of a bounded runtime channel.
+pub trait ChannelSender<T>: Clone + Send + Sync
+where
+    T: Send + 'static,
+{
+    /// Sends one item, waiting until capacity is available.
+    fn send(&self, item: T) -> impl Future<Output = Result<(), ChannelError>> + Send;
+
+    /// Attempts to send one item without waiting for capacity.
+    fn try_send(&self, item: T) -> Result<(), ChannelError>;
+}
+
+/// Async receiver half of a bounded runtime channel.
+pub trait ChannelReceiver<T>: Send
+where
+    T: Send + 'static,
+{
+    /// Receives the next item from the channel.
+    fn recv(&mut self) -> impl Future<Output = Result<T, ChannelError>> + Send;
+}
+
+/// Generic async runtime contract shared by protocol adapters.
+///
+/// Implementations are intended for executor ecosystems such as Tokio, async-std, or embassy.
+/// The trait focuses on the minimum orchestration pieces protocol drivers usually need:
+/// task spawning, bounded channels, and timers.
+pub trait AsyncRuntime: Clone + Send + Sync + 'static {
+    /// Task handle returned by `spawn`.
+    type Task<T>: TaskHandle<T>
+    where
+        T: Send + 'static;
+
+    /// Bounded channel sender created by `channel`.
+    type Sender<T>: ChannelSender<T>
+    where
+        T: Send + 'static;
+
+    /// Bounded channel receiver created by `channel`.
+    type Receiver<T>: ChannelReceiver<T>
+    where
+        T: Send + 'static;
+
+    /// Spawns one background future onto the runtime.
+    fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+
+    /// Creates one bounded channel suitable for backpressure-aware event pipelines.
+    fn channel<T>(&self, capacity: usize) -> (Self::Sender<T>, Self::Receiver<T>)
+    where
+        T: Send + 'static;
+
+    /// Suspends the current task for the requested duration.
+    fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::{
+        pin::Pin,
+        task::{Context, Poll, Waker},
+    };
+
+    #[derive(Clone, Default)]
+    struct MockRuntime;
+
+    struct MockTask<T>(Option<T>);
+
+    impl<T> TaskHandle<T> for MockTask<T>
+    where
+        T: Send + 'static,
+    {
+        async fn join(&mut self) -> Result<T, TaskJoinError> {
+            self.0.take().ok_or(TaskJoinError::Cancelled)
+        }
+
+        fn abort(&self) {}
+
+        fn is_finished(&self) -> bool {
+            self.0.is_some()
+        }
+    }
+
+    struct MockSender<T>(core::marker::PhantomData<fn() -> T>);
+
+    impl<T> Clone for MockSender<T> {
+        fn clone(&self) -> Self {
+            Self(core::marker::PhantomData)
+        }
+    }
+
+    impl<T> Default for MockSender<T> {
+        fn default() -> Self {
+            Self(core::marker::PhantomData)
+        }
+    }
+
+    impl<T> ChannelSender<T> for MockSender<T>
+    where
+        T: Send + 'static,
+    {
+        async fn send(&self, _item: T) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        fn try_send(&self, _item: T) -> Result<(), ChannelError> {
+            Ok(())
+        }
+    }
+
+    struct MockReceiver<T>(core::marker::PhantomData<fn() -> T>);
+
+    impl<T> Default for MockReceiver<T> {
+        fn default() -> Self {
+            Self(core::marker::PhantomData)
+        }
+    }
+
+    impl<T> ChannelReceiver<T> for MockReceiver<T>
+    where
+        T: Send + 'static,
+    {
+        async fn recv(&mut self) -> Result<T, ChannelError> {
+            Err(ChannelError::Closed)
+        }
+    }
+
+    impl AsyncRuntime for MockRuntime {
+        type Task<T>
+            = MockTask<T>
+        where
+            T: Send + 'static;
+        type Sender<T>
+            = MockSender<T>
+        where
+            T: Send + 'static;
+        type Receiver<T>
+            = MockReceiver<T>
+        where
+            T: Send + 'static;
+
+        fn spawn<F>(&self, _future: F) -> Self::Task<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            MockTask(None)
+        }
+
+        fn channel<T>(&self, _capacity: usize) -> (Self::Sender<T>, Self::Receiver<T>)
+        where
+            T: Send + 'static,
+        {
+            (MockSender::default(), MockReceiver::default())
+        }
+
+        async fn sleep(&self, _duration: Duration) {}
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        let mut future = Pin::from(Box::new(future));
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => core::hint::spin_loop(),
+            }
+        }
+    }
+
+    #[test]
+    fn mock_runtime_contract_is_usable() {
+        let runtime = MockRuntime;
+        let (sender, mut receiver) = runtime.channel::<u8>(4);
+        let _task = runtime.spawn(async { 42u8 });
+
+        assert!(block_on(sender.send(1)).is_ok());
+        assert!(sender.try_send(2).is_ok());
+        assert_eq!(block_on(receiver.recv()), Err(ChannelError::Closed));
+        block_on(runtime.sleep(Duration::from_millis(0)));
+    }
+}

--- a/crates/ferredge-core/src/runtime.rs
+++ b/crates/ferredge-core/src/runtime.rs
@@ -1,5 +1,7 @@
 use core::{future::Future, time::Duration};
 
+use crate::sync::AsyncMutex;
+
 /// Error returned by runtime-backed task handles.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskJoinError {
@@ -20,6 +22,15 @@ pub enum ChannelError {
     Closed,
     /// Channel operation failed because runtime resources are unavailable.
     RuntimeUnavailable,
+}
+
+/// Monotonic instant returned by a runtime clock.
+///
+/// Implementations should represent a monotonically increasing point in time suitable for
+/// elapsed-duration checks used by protocol keepalive and timeout logic.
+pub trait RuntimeInstant: Clone + Send + Sync + 'static {
+    /// Returns the duration elapsed since this instant was captured.
+    fn elapsed(&self) -> Duration;
 }
 
 /// Handle returned by runtime task spawning.
@@ -85,6 +96,14 @@ pub trait AsyncRuntime: Clone + Send + Sync + 'static {
     where
         T: Send + 'static;
 
+    /// Async mutex type created by `mutex`.
+    type Mutex<T>: AsyncMutex<T>
+    where
+        T: Send + 'static;
+
+    /// Monotonic instant type returned by `now`.
+    type Instant: RuntimeInstant;
+
     /// Spawns one background future onto the runtime.
     fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
     where
@@ -95,6 +114,14 @@ pub trait AsyncRuntime: Clone + Send + Sync + 'static {
     fn channel<T>(&self, capacity: usize) -> (Self::Sender<T>, Self::Receiver<T>)
     where
         T: Send + 'static;
+
+    /// Creates one async mutex backed by the selected runtime.
+    fn mutex<T>(&self, value: T) -> Self::Mutex<T>
+    where
+        T: Send + 'static;
+
+    /// Returns the current monotonic instant for elapsed-time checks.
+    fn now(&self) -> Self::Instant;
 
     /// Suspends the current task for the requested duration.
     fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send;
@@ -156,6 +183,24 @@ mod tests {
     }
 
     struct MockReceiver<T>(core::marker::PhantomData<fn() -> T>);
+    struct MockMutex<T>(std::sync::Mutex<T>);
+    struct MockGuard<'a, T>(std::sync::MutexGuard<'a, T>);
+    #[derive(Clone)]
+    struct MockInstant(std::time::Instant);
+
+    impl<T> core::ops::Deref for MockGuard<'_, T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T> core::ops::DerefMut for MockGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
 
     impl<T> Default for MockReceiver<T> {
         fn default() -> Self {
@@ -176,6 +221,36 @@ mod tests {
         }
     }
 
+    impl<T> AsyncMutex<T> for MockMutex<T>
+    where
+        T: Send + 'static,
+    {
+        type Guard<'a>
+            = MockGuard<'a, T>
+        where
+            T: 'a;
+
+        async fn lock(&self) -> Result<Self::Guard<'_>, crate::sync::MutexError> {
+            self.0
+                .lock()
+                .map(MockGuard)
+                .map_err(|_| crate::sync::MutexError::RuntimeUnavailable)
+        }
+
+        fn try_lock(&self) -> Result<Self::Guard<'_>, crate::sync::MutexError> {
+            self.0
+                .try_lock()
+                .map(MockGuard)
+                .map_err(|_| crate::sync::MutexError::Busy)
+        }
+    }
+
+    impl RuntimeInstant for MockInstant {
+        fn elapsed(&self) -> Duration {
+            self.0.elapsed()
+        }
+    }
+
     impl AsyncRuntime for MockRuntime {
         type Task<T>
             = MockTask<T>
@@ -189,6 +264,11 @@ mod tests {
             = MockReceiver<T>
         where
             T: Send + 'static;
+        type Mutex<T>
+            = MockMutex<T>
+        where
+            T: Send + 'static;
+        type Instant = MockInstant;
 
         fn spawn<F>(&self, _future: F) -> Self::Task<F::Output>
         where
@@ -203,6 +283,17 @@ mod tests {
             T: Send + 'static,
         {
             (MockSender::default(), MockReceiver::default())
+        }
+
+        fn mutex<T>(&self, value: T) -> Self::Mutex<T>
+        where
+            T: Send + 'static,
+        {
+            MockMutex(std::sync::Mutex::new(value))
+        }
+
+        fn now(&self) -> Self::Instant {
+            MockInstant(std::time::Instant::now())
         }
 
         async fn sleep(&self, _duration: Duration) {}

--- a/crates/ferredge-core/src/runtime.rs
+++ b/crates/ferredge-core/src/runtime.rs
@@ -14,6 +14,8 @@ pub enum TaskJoinError {
 pub enum ChannelError {
     /// Channel is full and cannot currently accept more messages.
     Full,
+    /// Channel currently has no item available for nonblocking receive.
+    Empty,
     /// Channel was closed by the receiver or runtime.
     Closed,
     /// Channel operation failed because runtime resources are unavailable.
@@ -57,6 +59,9 @@ where
 {
     /// Receives the next item from the channel.
     fn recv(&mut self) -> impl Future<Output = Result<T, ChannelError>> + Send;
+
+    /// Attempts to receive one item without waiting.
+    fn try_recv(&mut self) -> Result<T, ChannelError>;
 }
 
 /// Generic async runtime contract shared by protocol adapters.
@@ -163,6 +168,10 @@ mod tests {
         T: Send + 'static,
     {
         async fn recv(&mut self) -> Result<T, ChannelError> {
+            Err(ChannelError::Closed)
+        }
+
+        fn try_recv(&mut self) -> Result<T, ChannelError> {
             Err(ChannelError::Closed)
         }
     }

--- a/crates/ferredge-core/src/sync.rs
+++ b/crates/ferredge-core/src/sync.rs
@@ -1,0 +1,39 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+use core::{future::Future, ops::DerefMut};
+
+#[cfg(feature = "std")]
+pub use std::sync::Arc as Shared;
+
+#[cfg(not(feature = "std"))]
+pub use alloc::sync::Arc as Shared;
+
+pub use core::sync::atomic::{AtomicBool as AtomicFlag, Ordering as AtomicOrdering};
+
+/// Error returned by async mutex operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MutexError {
+    /// Mutex is currently held by another task and try-lock could not acquire it.
+    Busy,
+    /// Locking failed because the underlying runtime is unavailable.
+    RuntimeUnavailable,
+}
+
+/// Async mutex contract used by protocol crates without tying them to one executor.
+pub trait AsyncMutex<T>: Send + Sync
+where
+    T: Send + 'static,
+{
+    /// Guard type returned by mutex lock operations.
+    type Guard<'a>: DerefMut<Target = T> + 'a
+    where
+        Self: 'a,
+        T: 'a;
+
+    /// Waits until the mutex can be acquired.
+    fn lock(&self) -> impl Future<Output = Result<Self::Guard<'_>, MutexError>> + Send;
+
+    /// Attempts to acquire the mutex without waiting.
+    fn try_lock(&self) -> Result<Self::Guard<'_>, MutexError>;
+}

--- a/crates/ferredge-proto-http/Cargo.toml
+++ b/crates/ferredge-proto-http/Cargo.toml
@@ -8,13 +8,19 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["std"]
+default = ["tokio-runtime"]
 std = ["serde/std", "httparse/std", "ferredge-core/std"]
+tokio-runtime = ["std", "dep:ferredge-runtime-tokio"]
+async-std-runtime = ["std", "dep:ferredge-runtime-async-std"]
+embassy-runtime = ["dep:ferredge-runtime-embassy"]
 
 [dependencies]
 httparse = { version = "1.10.1", default-features = false }
 serde = { workspace = true }
 ferredge-core = { workspace = true }
 anyhow = { workspace = true }
+ferredge-runtime-tokio = { workspace = true, optional = true }
+ferredge-runtime-async-std = { workspace = true, optional = true }
+ferredge-runtime-embassy = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/ferredge-proto-http/src/attributes.rs
+++ b/crates/ferredge-proto-http/src/attributes.rs
@@ -1,3 +1,6 @@
+extern crate alloc;
+
+use alloc::{string::String, vec::Vec};
 use ferredge_core::prelude::DeviceResourceAttributes;
 use serde::{Deserialize, Serialize};
 

--- a/crates/ferredge-proto-http/src/attributes.rs
+++ b/crates/ferredge-proto-http/src/attributes.rs
@@ -1,10 +1,14 @@
 use ferredge_core::prelude::DeviceResourceAttributes;
 use serde::{Deserialize, Serialize};
 
+/// HTTP-specific resource metadata used to build outbound requests.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HttpResourceAttributes {
+    /// Request path for this resource.
     pub slug: String,
+    /// HTTP method to use when interacting with this resource.
     pub method: String,
+    /// Optional static headers attached to requests for this resource.
     pub headers: Option<Vec<(String, String)>>,
 }
 

--- a/crates/ferredge-proto-http/src/handler.rs
+++ b/crates/ferredge-proto-http/src/handler.rs
@@ -1,261 +1,54 @@
 #[cfg(feature = "std")]
-use {
-    httparse::{Request, Status},
-    std::{
-        io::{Read, Write},
-        net::TcpStream,
-    },
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
 };
 
-use crate::attributes::HttpResourceAttributes;
+use crate::HttpRequest;
 
+/// Sends one native HTTP request to endpoint and returns raw response bytes.
 #[cfg(feature = "std")]
-pub fn send_request(
-    mut stream: &TcpStream,
-    endpoint: &str,
-    attrs: &HttpResourceAttributes,
-) -> Result<Option<Vec<u8>>, anyhow::Error> {
-    let mut buffer = [0; 512];
-    let bytes_read = stream.read(&mut buffer).map_err(|e| anyhow::anyhow!(e))?;
+pub fn send_request(endpoint: &str, request: &HttpRequest) -> Result<Vec<u8>, anyhow::Error> {
+    let mut wire_request = format!(
+        "{} {} HTTP/1.1\r\nHost: {}\r\n",
+        request.method, request.path, endpoint
+    );
 
-    let mut headers = [httparse::EMPTY_HEADER; 16];
-    let mut req = Request::new(&mut headers);
-    let status = req
-        .parse(&buffer[..bytes_read])
-        .map_err(|e| anyhow::anyhow!(e))?;
-    match status {
-        Status::Complete(_) => {
-            // Build the HTTP request
-            let mut request = format!(
-                "{} {} HTTP/1.1\r\nHost: {}\r\n",
-                attrs.method, attrs.slug, endpoint
-            );
-
-            // Add custom headers if provided
-            if let Some(headers) = &attrs.headers {
-                for (key, value) in headers {
-                    request.push_str(&format!("{}: {}\r\n", key, value));
-                }
-            }
-
-            // Add default headers
-            request.push_str("Connection: close\r\n");
-            request.push_str("\r\n");
-
-            // Connect to the endpoint and send the request
-            let mut upstream = TcpStream::connect(endpoint)
-                .map_err(|e| anyhow::anyhow!("Failed to connect to endpoint: {}", e))?;
-
-            upstream
-                .write_all(request.as_bytes())
-                .map_err(|e| anyhow::anyhow!("Failed to send request: {}", e))?;
-
-            // Read the response
-            let mut response = Vec::new();
-            upstream
-                .read_to_end(&mut response)
-                .map_err(|e| anyhow::anyhow!("Failed to read response: {}", e))?;
-
-            Ok(Some(response))
-        }
-        Status::Partial => Err(anyhow::anyhow!("Incomplete HTTP request")),
+    for (key, value) in &request.headers {
+        wire_request.push_str(&format!("{key}: {value}\r\n"));
     }
+
+    if let Some(body) = &request.body {
+        wire_request.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    }
+
+    wire_request.push_str("Connection: close\r\n\r\n");
+
+    let mut upstream = TcpStream::connect(endpoint)
+        .map_err(|e| anyhow::anyhow!("Failed to connect to endpoint: {e}"))?;
+
+    upstream
+        .write_all(wire_request.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Failed to send request: {e}"))?;
+
+    if let Some(body) = &request.body {
+        upstream
+            .write_all(body)
+            .map_err(|e| anyhow::anyhow!("Failed to send request body: {e}"))?;
+    }
+
+    let mut response = Vec::new();
+    upstream
+        .read_to_end(&mut response)
+        .map_err(|e| anyhow::anyhow!("Failed to read response: {e}"))?;
+
+    Ok(response)
 }
 
+/// Placeholder no_std handler until HTTP transport support is introduced there.
 #[cfg(not(feature = "std"))]
-pub fn send_request(
-    _stream: &(),
-    _endpoint: &str,
-    _attrs: &HttpResourceAttributes,
-) -> Result<Option<Vec<u8>>, anyhow::Error> {
+pub fn send_request(_endpoint: &str, _request: &HttpRequest) -> Result<Vec<u8>, anyhow::Error> {
     Err(anyhow::anyhow!(
         "HTTP driver not implemented for no_std environment"
     ))
-}
-
-#[cfg(all(test, feature = "std"))]
-mod tests {
-    use super::*;
-    use std::io::Write;
-    use std::net::{TcpListener, TcpStream};
-    use std::thread;
-    use std::time::Duration;
-
-    /// Helper function to create a mock HTTP server that responds to requests
-    fn create_mock_server(response: &'static str) -> String {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to address");
-        let addr = listener.local_addr().expect("Failed to get local address");
-
-        thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
-                let mut buffer = [0; 512];
-                let _ = stream.read(&mut buffer);
-                let _ = stream.write_all(response.as_bytes());
-            }
-        });
-
-        // Give the server time to start
-        thread::sleep(Duration::from_millis(50));
-
-        addr.to_string()
-    }
-
-    /// Helper function to create a client stream with a mock request
-    fn create_mock_client_stream(request: &str) -> TcpStream {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind");
-        let addr = listener.local_addr().expect("Failed to get local address");
-
-        // Spawn a thread to write the request
-        let request_owned = request.to_string();
-        thread::spawn(move || {
-            let mut stream = TcpStream::connect(addr).expect("Failed to connect");
-            stream
-                .write_all(request_owned.as_bytes())
-                .expect("Failed to write");
-        });
-
-        // Accept the connection
-        thread::sleep(Duration::from_millis(50));
-        let (stream, _) = listener.accept().expect("Failed to accept");
-        stream
-    }
-
-    #[test]
-    fn test_send_request_basic_get() {
-        let response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!";
-        let endpoint = create_mock_server(response);
-
-        let client_stream =
-            create_mock_client_stream("GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/test".to_string(),
-            method: "GET".to_string(),
-            headers: None,
-        };
-
-        let result = send_request(&client_stream, &endpoint, &attrs);
-        assert!(result.is_ok());
-
-        let response_data = result.unwrap();
-
-        assert!(response_data.is_some());
-        let binding = response_data.unwrap();
-        let response_str = String::from_utf8_lossy(&binding);
-        assert!(response_str.contains("200 OK"));
-        assert!(response_str.contains("Hello, World!"));
-    }
-
-    #[test]
-    fn test_send_request_with_custom_headers() {
-        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK";
-        let endpoint = create_mock_server(response);
-
-        let client_stream =
-            create_mock_client_stream("GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/data".to_string(),
-            method: "GET".to_string(),
-            headers: Some(vec![
-                ("Authorization".to_string(), "Bearer token123".to_string()),
-                ("Content-Type".to_string(), "application/json".to_string()),
-            ]),
-        };
-
-        let result = send_request(&client_stream, &endpoint, &attrs);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_some());
-    }
-
-    #[test]
-    fn test_send_request_post_method() {
-        let response = "HTTP/1.1 201 Created\r\nContent-Length: 7\r\n\r\nCreated";
-        let endpoint = create_mock_server(response);
-
-        let client_stream =
-            create_mock_client_stream("POST /test HTTP/1.1\r\nHost: example.com\r\n\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/create".to_string(),
-            method: "POST".to_string(),
-            headers: Some(vec![(
-                "Content-Type".to_string(),
-                "application/json".to_string(),
-            )]),
-        };
-
-        let result = send_request(&client_stream, &endpoint, &attrs);
-        assert!(result.is_ok());
-
-        let response_data = result.unwrap();
-        assert!(response_data.is_some());
-
-        let binding = response_data.unwrap();
-        let response_str = String::from_utf8_lossy(&binding);
-        assert!(response_str.contains("201 Created"));
-    }
-
-    #[test]
-    fn test_send_request_partial_request() {
-        // Send an incomplete HTTP request
-        let client_stream = create_mock_client_stream("GET /test HTTP/1.1\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/test".to_string(),
-            method: "GET".to_string(),
-            headers: None,
-        };
-
-        // This should fail because the request is incomplete
-        let result = send_request(&client_stream, "127.0.0.1:9999", &attrs);
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Incomplete HTTP request")
-        );
-    }
-
-    #[test]
-    fn test_send_request_invalid_endpoint() {
-        let client_stream =
-            create_mock_client_stream("GET /test HTTP/1.1\r\nHost: example.com\r\n\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/test".to_string(),
-            method: "GET".to_string(),
-            headers: None,
-        };
-
-        // Use an invalid endpoint that should fail to connect
-        let result = send_request(&client_stream, "127.0.0.1:99999", &attrs);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_send_request_empty_response() {
-        let response = "HTTP/1.1 204 No Content\r\n\r\n";
-        let endpoint = create_mock_server(response);
-
-        let client_stream =
-            create_mock_client_stream("DELETE /test HTTP/1.1\r\nHost: example.com\r\n\r\n");
-
-        let attrs = HttpResourceAttributes {
-            slug: "/api/delete/123".to_string(),
-            method: "DELETE".to_string(),
-            headers: None,
-        };
-
-        let result = send_request(&client_stream, &endpoint, &attrs);
-        assert!(result.is_ok());
-
-        let response_data = result.unwrap();
-        assert!(response_data.is_some());
-
-        let binding = response_data.unwrap();
-        let response_str = String::from_utf8_lossy(&binding);
-        assert!(response_str.contains("204 No Content"));
-    }
 }

--- a/crates/ferredge-proto-http/src/handler.rs
+++ b/crates/ferredge-proto-http/src/handler.rs
@@ -2,9 +2,15 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use alloc::format;
+use alloc::string::{String, ToString};
 use ferredge_core::prelude::{AsyncNet, AsyncRuntime, AsyncSocket, NetError};
 
 use crate::HttpRequest;
+
+struct ParsedEndpoint {
+    connect_target: String,
+    host_header: String,
+}
 
 /// Sends one native HTTP request to endpoint and returns raw response bytes.
 pub async fn send_request<N, R>(
@@ -17,9 +23,10 @@ where
     N: AsyncNet,
     R: AsyncRuntime,
 {
+    let parsed_endpoint = parse_endpoint(endpoint)?;
     let mut wire_request = format!(
         "{} {} HTTP/1.1\r\nHost: {}\r\n",
-        request.method, request.path, endpoint
+        request.method, request.path, parsed_endpoint.host_header
     );
 
     for (key, value) in &request.headers {
@@ -33,7 +40,7 @@ where
     wire_request.push_str("Connection: close\r\n\r\n");
 
     let mut upstream = net
-        .connect(endpoint)
+        .connect(parsed_endpoint.connect_target.as_str())
         .await
         .map_err(|e| anyhow::anyhow!("Failed to connect to endpoint: {e:?}"))?;
 
@@ -68,6 +75,53 @@ where
     Ok(response)
 }
 
+fn parse_endpoint(endpoint: &str) -> Result<ParsedEndpoint, anyhow::Error> {
+    let (authority_and_path, default_port) = if let Some(rest) = endpoint.strip_prefix("http://") {
+        (rest, 80)
+    } else if let Some(rest) = endpoint.strip_prefix("https://") {
+        (rest, 443)
+    } else {
+        (endpoint, 80)
+    };
+
+    let authority = authority_and_path
+        .split('/')
+        .next()
+        .filter(|authority| !authority.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("HTTP endpoint missing authority"))?;
+
+    if authority.starts_with('[') {
+        let Some(bracket_end) = authority.find(']') else {
+            return Err(anyhow::anyhow!("HTTP endpoint has malformed IPv6 authority"));
+        };
+
+        let suffix = &authority[bracket_end + 1..];
+        return match suffix {
+            "" => Ok(ParsedEndpoint {
+                connect_target: format!("{authority}:{default_port}"),
+                host_header: authority.to_string(),
+            }),
+            _ if suffix.starts_with(':') => Ok(ParsedEndpoint {
+                connect_target: authority.to_string(),
+                host_header: authority.to_string(),
+            }),
+            _ => Err(anyhow::anyhow!("HTTP endpoint has malformed IPv6 authority")),
+        };
+    }
+
+    if authority.contains(':') {
+        Ok(ParsedEndpoint {
+            connect_target: authority.to_string(),
+            host_header: authority.to_string(),
+        })
+    } else {
+        Ok(ParsedEndpoint {
+            connect_target: format!("{authority}:{default_port}"),
+            host_header: authority.to_string(),
+        })
+    }
+}
+
 async fn write_all_socket<S: AsyncSocket>(socket: &mut S, mut buf: &[u8]) -> Result<(), NetError> {
     while !buf.is_empty() {
         let written = socket.write(buf).await?;
@@ -77,4 +131,51 @@ async fn write_all_socket<S: AsyncSocket>(socket: &mut S, mut buf: &[u8]) -> Res
         buf = &buf[written..];
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_endpoint;
+
+    #[test]
+    fn parse_endpoint_adds_default_ports() {
+        let parsed = parse_endpoint("example.com").expect("host should parse");
+        assert_eq!(parsed.connect_target, "example.com:80");
+        assert_eq!(parsed.host_header, "example.com");
+
+        let parsed = parse_endpoint("http://example.com").expect("http url should parse");
+        assert_eq!(parsed.connect_target, "example.com:80");
+        assert_eq!(parsed.host_header, "example.com");
+
+        let parsed = parse_endpoint("https://example.com").expect("https url should parse");
+        assert_eq!(parsed.connect_target, "example.com:443");
+        assert_eq!(parsed.host_header, "example.com");
+    }
+
+    #[test]
+    fn parse_endpoint_handles_bracketed_ipv6() {
+        let parsed = parse_endpoint("[::1]").expect("ipv6 host should parse");
+        assert_eq!(parsed.connect_target, "[::1]:80");
+        assert_eq!(parsed.host_header, "[::1]");
+
+        let parsed = parse_endpoint("http://[::1]").expect("ipv6 url should parse");
+        assert_eq!(parsed.connect_target, "[::1]:80");
+        assert_eq!(parsed.host_header, "[::1]");
+
+        let parsed = parse_endpoint("https://[::1]").expect("ipv6 https url should parse");
+        assert_eq!(parsed.connect_target, "[::1]:443");
+        assert_eq!(parsed.host_header, "[::1]");
+
+        let parsed = parse_endpoint("http://[::1]:8080").expect("ipv6 with port should parse");
+        assert_eq!(parsed.connect_target, "[::1]:8080");
+        assert_eq!(parsed.host_header, "[::1]:8080");
+    }
+
+    #[test]
+    fn parse_endpoint_strips_path_before_connect() {
+        let parsed =
+            parse_endpoint("https://example.com/api/v1").expect("url with path should parse");
+        assert_eq!(parsed.connect_target, "example.com:443");
+        assert_eq!(parsed.host_header, "example.com");
+    }
 }

--- a/crates/ferredge-proto-http/src/handler.rs
+++ b/crates/ferredge-proto-http/src/handler.rs
@@ -1,8 +1,8 @@
 extern crate alloc;
 
-use alloc::vec::Vec;
 use alloc::format;
 use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use ferredge_core::prelude::{AsyncNet, AsyncRuntime, AsyncSocket, NetError};
 
 use crate::HttpRequest;
@@ -92,7 +92,9 @@ fn parse_endpoint(endpoint: &str) -> Result<ParsedEndpoint, anyhow::Error> {
 
     if authority.starts_with('[') {
         let Some(bracket_end) = authority.find(']') else {
-            return Err(anyhow::anyhow!("HTTP endpoint has malformed IPv6 authority"));
+            return Err(anyhow::anyhow!(
+                "HTTP endpoint has malformed IPv6 authority"
+            ));
         };
 
         let suffix = &authority[bracket_end + 1..];
@@ -105,7 +107,9 @@ fn parse_endpoint(endpoint: &str) -> Result<ParsedEndpoint, anyhow::Error> {
                 connect_target: authority.to_string(),
                 host_header: authority.to_string(),
             }),
-            _ => Err(anyhow::anyhow!("HTTP endpoint has malformed IPv6 authority")),
+            _ => Err(anyhow::anyhow!(
+                "HTTP endpoint has malformed IPv6 authority"
+            )),
         };
     }
 

--- a/crates/ferredge-proto-http/src/handler.rs
+++ b/crates/ferredge-proto-http/src/handler.rs
@@ -1,14 +1,22 @@
-#[cfg(feature = "std")]
-use std::{
-    io::{Read, Write},
-    net::TcpStream,
-};
+extern crate alloc;
+
+use alloc::vec::Vec;
+use alloc::format;
+use ferredge_core::prelude::{AsyncNet, AsyncRuntime, AsyncSocket, NetError};
 
 use crate::HttpRequest;
 
 /// Sends one native HTTP request to endpoint and returns raw response bytes.
-#[cfg(feature = "std")]
-pub fn send_request(endpoint: &str, request: &HttpRequest) -> Result<Vec<u8>, anyhow::Error> {
+pub async fn send_request<N, R>(
+    endpoint: &str,
+    request: &HttpRequest,
+    _runtime: &R,
+    net: &N,
+) -> Result<Vec<u8>, anyhow::Error>
+where
+    N: AsyncNet,
+    R: AsyncRuntime,
+{
     let mut wire_request = format!(
         "{} {} HTTP/1.1\r\nHost: {}\r\n",
         request.method, request.path, endpoint
@@ -24,31 +32,49 @@ pub fn send_request(endpoint: &str, request: &HttpRequest) -> Result<Vec<u8>, an
 
     wire_request.push_str("Connection: close\r\n\r\n");
 
-    let mut upstream = TcpStream::connect(endpoint)
-        .map_err(|e| anyhow::anyhow!("Failed to connect to endpoint: {e}"))?;
+    let mut upstream = net
+        .connect(endpoint)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to connect to endpoint: {e:?}"))?;
 
-    upstream
-        .write_all(wire_request.as_bytes())
-        .map_err(|e| anyhow::anyhow!("Failed to send request: {e}"))?;
+    write_all_socket(&mut upstream, wire_request.as_bytes())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to send request: {e:?}"))?;
 
     if let Some(body) = &request.body {
-        upstream
-            .write_all(body)
-            .map_err(|e| anyhow::anyhow!("Failed to send request body: {e}"))?;
+        write_all_socket(&mut upstream, body)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to send request body: {e:?}"))?;
     }
 
-    let mut response = Vec::new();
     upstream
-        .read_to_end(&mut response)
-        .map_err(|e| anyhow::anyhow!("Failed to read response: {e}"))?;
+        .flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to flush request: {e:?}"))?;
+
+    let mut response = Vec::new();
+    let mut buffer = [0u8; 4096];
+    loop {
+        let count = upstream
+            .read(&mut buffer)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read response: {e:?}"))?;
+        if count == 0 {
+            break;
+        }
+        response.extend_from_slice(&buffer[..count]);
+    }
 
     Ok(response)
 }
 
-/// Placeholder no_std handler until HTTP transport support is introduced there.
-#[cfg(not(feature = "std"))]
-pub fn send_request(_endpoint: &str, _request: &HttpRequest) -> Result<Vec<u8>, anyhow::Error> {
-    Err(anyhow::anyhow!(
-        "HTTP driver not implemented for no_std environment"
-    ))
+async fn write_all_socket<S: AsyncSocket>(socket: &mut S, mut buf: &[u8]) -> Result<(), NetError> {
+    while !buf.is_empty() {
+        let written = socket.write(buf).await?;
+        if written == 0 {
+            return Err(NetError::Closed);
+        }
+        buf = &buf[written..];
+    }
+    Ok(())
 }

--- a/crates/ferredge-proto-http/src/lib.rs
+++ b/crates/ferredge-proto-http/src/lib.rs
@@ -59,15 +59,22 @@ pub struct HttpDriver {
     pub dvc: Device<attributes::HttpResourceAttributes>,
 }
 
-impl HttpDriver {
-    /// Builds a concrete HTTP request from routed command and device resource metadata.
-    pub fn try_request_from_command(
-        &self,
-        command: &Command,
-    ) -> Result<HttpRequest, HttpCommandConversionError> {
-        match &command.intent {
-            Intent::Read { resource } | Intent::Invoke { operation: resource, .. } => self
-                .dvc
+/// Viewer that carries enough context to convert routed command into native HTTP request.
+#[derive(Debug, Clone, Copy)]
+pub struct HttpCommandRef<'a> {
+    /// Driver-side device metadata used to resolve resources.
+    pub device: &'a Device<attributes::HttpResourceAttributes>,
+    /// Routed command to convert.
+    pub command: &'a Command,
+}
+
+impl TryFrom<HttpCommandRef<'_>> for HttpRequest {
+    type Error = HttpCommandConversionError;
+
+    fn try_from(value: HttpCommandRef<'_>) -> Result<Self, Self::Error> {
+        match &value.command.intent {
+            Intent::Read { resource } | Intent::Invoke { operation: resource, .. } => value
+                .device
                 .resources
                 .get(resource)
                 .map(|resource| HttpRequest {
@@ -81,8 +88,8 @@ impl HttpDriver {
                         .unwrap_or_default(),
                 })
                 .ok_or_else(|| HttpCommandConversionError::UnknownResource(resource.clone())),
-            Intent::Write { resource, payload } => self
-                .dvc
+            Intent::Write { resource, payload } => value
+                .device
                 .resources
                 .get(resource)
                 .map(|resource| HttpRequest {
@@ -135,5 +142,139 @@ impl RequestResponse for HttpDriver {
     #[cfg(not(feature = "std"))]
     async fn execute(&self, _request: Self::Request) -> Result<Self::Response, Self::Error> {
         Err("HTTP driver not implemented for no_std environment".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ferredge_core::prelude::{
+        BrokerAddress, BrokerChannelKind, BrokerMessageOptions, DeviceEndpoint,
+        DeviceResourceAccessPermission, DeviceStatus, HttpEndpointConfig, Intent, Map,
+    };
+
+    fn make_driver() -> HttpDriver {
+        let mut resources = Map::default();
+        resources.insert(
+            "temp".to_string(),
+            DeviceResource {
+                name: "temp".to_string(),
+                resource_attributes: attributes::HttpResourceAttributes {
+                    slug: "/api/temp".to_string(),
+                    method: "GET".to_string(),
+                    headers: Some(vec![("Accept".to_string(), "application/json".to_string())]),
+                },
+                unit: Some("C".to_string()),
+                permission: Some(DeviceResourceAccessPermission::READ),
+            },
+        );
+        resources.insert(
+            "setpoint".to_string(),
+            DeviceResource {
+                name: "setpoint".to_string(),
+                resource_attributes: attributes::HttpResourceAttributes {
+                    slug: "/api/setpoint".to_string(),
+                    method: "POST".to_string(),
+                    headers: None,
+                },
+                unit: Some("C".to_string()),
+                permission: Some(DeviceResourceAccessPermission::WRITE),
+            },
+        );
+
+        HttpDriver {
+            dvc: Device {
+                id: "device-1".to_string(),
+                name: "HTTP Device".to_string(),
+                status: DeviceStatus::Online,
+                endpoint: DeviceEndpoint::http(HttpEndpointConfig {
+                    url: "127.0.0.1:8080".to_string(),
+                }),
+                metadata: None,
+                max_connections: Some(4),
+                resources,
+                message_endpoints: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn read_command_converts_to_http_request() {
+        let driver = make_driver();
+        let command = Command {
+            id: "cmd-1".to_string(),
+            source_device_id: None,
+            target_device_id: "device-1".to_string(),
+            intent: Intent::Read {
+                resource: "temp".to_string(),
+            },
+            correlation: None,
+        };
+
+        let request = HttpRequest::try_from(HttpCommandRef {
+            device: &driver.dvc,
+            command: &command,
+        })
+        .expect("read intent should convert");
+
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.path, "/api/temp");
+        assert_eq!(request.body, None);
+        assert_eq!(
+            request.headers,
+            vec![("Accept".to_string(), "application/json".to_string())]
+        );
+    }
+
+    #[test]
+    fn write_command_converts_to_http_request_with_body() {
+        let driver = make_driver();
+        let command = Command {
+            id: "cmd-2".to_string(),
+            source_device_id: None,
+            target_device_id: "device-1".to_string(),
+            intent: Intent::Write {
+                resource: "setpoint".to_string(),
+                payload: b"42".to_vec(),
+            },
+            correlation: None,
+        };
+
+        let request = HttpRequest::try_from(HttpCommandRef {
+            device: &driver.dvc,
+            command: &command,
+        })
+        .expect("write intent should convert");
+
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/api/setpoint");
+        assert_eq!(request.body, Some(b"42".to_vec()));
+    }
+
+    #[test]
+    fn broker_send_intent_is_rejected_for_http() {
+        let driver = make_driver();
+        let command = Command {
+            id: "cmd-3".to_string(),
+            source_device_id: None,
+            target_device_id: "device-1".to_string(),
+            intent: Intent::Send {
+                channel: BrokerAddress {
+                    name: "sensors.temp".to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+                payload: b"42".to_vec(),
+                options: BrokerMessageOptions::default(),
+            },
+            correlation: None,
+        };
+
+        let error = HttpRequest::try_from(HttpCommandRef {
+            device: &driver.dvc,
+            command: &command,
+        })
+        .expect_err("broker send intent should be unsupported");
+
+        assert_eq!(error, HttpCommandConversionError::UnsupportedIntent);
     }
 }

--- a/crates/ferredge-proto-http/src/lib.rs
+++ b/crates/ferredge-proto-http/src/lib.rs
@@ -1,16 +1,40 @@
-#[cfg(not(feature = "std"))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate alloc;
 
-#[cfg(feature = "std")]
-use std::{string::String, vec::Vec};
-
-#[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{string::{String, ToString}, vec::Vec};
 
 use ferredge_core::prelude::*;
 
 pub mod attributes;
 mod handler;
+#[cfg(all(feature = "tokio-runtime", feature = "async-std-runtime"))]
+compile_error!("ferredge-proto-http supports only one std runtime stack feature at a time");
+#[cfg(not(any(
+    feature = "tokio-runtime",
+    feature = "async-std-runtime",
+    feature = "embassy-runtime"
+)))]
+compile_error!("ferredge-proto-http requires one runtime stack feature");
+#[cfg(feature = "tokio-runtime")]
+mod runtime_stack {
+    pub use ferredge_runtime_tokio::{TokioNet as StackNet, TokioRuntime as StackRuntime};
+}
+#[cfg(feature = "async-std-runtime")]
+mod runtime_stack {
+    pub use ferredge_runtime_async_std::{AsyncStdNet as StackNet, AsyncStdRuntime as StackRuntime};
+}
+#[cfg(feature = "embassy-runtime")]
+mod runtime_stack {
+    pub use ferredge_runtime_embassy::{EmbassyNet as StackNet, EmbassyRuntime as StackRuntime};
+}
+
+#[cfg(any(
+    feature = "tokio-runtime",
+    feature = "async-std-runtime",
+    feature = "embassy-runtime"
+))]
+use runtime_stack::{StackNet, StackRuntime};
 
 /// Native outbound HTTP request used by the HTTP protocol adapter.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,10 +77,32 @@ impl core::fmt::Display for HttpCommandConversionError {
 }
 
 /// HTTP protocol adapter implementing lifecycle and request/response capabilities.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HttpDriver {
     /// Device metadata and resource map served by this driver.
     pub dvc: Device<attributes::HttpResourceAttributes>,
+    /// Selected runtime used by the live HTTP transport path.
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "async-std-runtime",
+        feature = "embassy-runtime"
+    ))]
+    runtime: StackRuntime,
+    /// Selected network adapter used by the live HTTP transport path.
+    #[cfg(any(
+        feature = "tokio-runtime",
+        feature = "async-std-runtime",
+        feature = "embassy-runtime"
+    ))]
+    net: StackNet,
+}
+
+impl core::fmt::Debug for HttpDriver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HttpDriver")
+            .field("dvc", &self.dvc)
+            .finish()
+    }
 }
 
 /// Viewer that carries enough context to convert routed command into native HTTP request.
@@ -66,6 +112,27 @@ pub struct HttpCommandRef<'a> {
     pub device: &'a Device<attributes::HttpResourceAttributes>,
     /// Routed command to convert.
     pub command: &'a Command,
+}
+
+impl HttpDriver {
+    /// Creates a new HTTP driver from device metadata.
+    pub fn new(dvc: Device<attributes::HttpResourceAttributes>) -> Self {
+        Self {
+            dvc,
+            #[cfg(any(
+                feature = "tokio-runtime",
+                feature = "async-std-runtime",
+                feature = "embassy-runtime"
+            ))]
+            runtime: StackRuntime::default(),
+            #[cfg(any(
+                feature = "tokio-runtime",
+                feature = "async-std-runtime",
+                feature = "embassy-runtime"
+            ))]
+            net: StackNet::default(),
+        }
+    }
 }
 
 impl TryFrom<HttpCommandRef<'_>> for HttpRequest {
@@ -127,21 +194,26 @@ impl RequestResponse for HttpDriver {
     type Response = HttpResponse;
     type Error = String;
 
-    #[cfg(feature = "std")]
     async fn execute(&self, request: Self::Request) -> Result<Self::Response, Self::Error> {
         let endpoint = match &self.dvc.endpoint {
             DeviceEndpoint::Http(config) => config.url.as_str(),
             _ => return Err("device endpoint is not HTTP".to_string()),
         };
 
-        handler::send_request(endpoint, &request)
-            .map(|body| HttpResponse { body })
-            .map_err(|e| e.to_string())
-    }
+        #[cfg(any(
+            feature = "tokio-runtime",
+            feature = "async-std-runtime",
+            feature = "embassy-runtime"
+        ))]
+        {
+            return handler::send_request(endpoint, &request, &self.runtime, &self.net)
+                .await
+                .map(|body| HttpResponse { body })
+                .map_err(|e| e.to_string());
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn execute(&self, _request: Self::Request) -> Result<Self::Response, Self::Error> {
-        Err("HTTP driver not implemented for no_std environment".to_string())
+        #[allow(unreachable_code)]
+        Err("HTTP driver runtime stack is unavailable".to_string())
     }
 }
 
@@ -182,8 +254,7 @@ mod tests {
             },
         );
 
-        HttpDriver {
-            dvc: Device {
+        HttpDriver::new(Device {
                 id: "device-1".to_string(),
                 name: "HTTP Device".to_string(),
                 status: DeviceStatus::Online,
@@ -194,8 +265,7 @@ mod tests {
                 max_connections: Some(4),
                 resources,
                 message_endpoints: Vec::new(),
-            },
-        }
+            })
     }
 
     #[test]

--- a/crates/ferredge-proto-http/src/lib.rs
+++ b/crates/ferredge-proto-http/src/lib.rs
@@ -1,60 +1,139 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 #[cfg(feature = "std")]
-use std::net::TcpStream;
+use std::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
 
 use ferredge_core::prelude::*;
 
 pub mod attributes;
 mod handler;
 
-#[derive(Debug)]
-pub struct HttpDriver {
-    dvc: Device<attributes::HttpResourceAttributes>,
+/// Native outbound HTTP request used by the HTTP protocol adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpRequest {
+    /// HTTP method sent to target endpoint.
+    pub method: String,
+    /// Request path or slug.
+    pub path: String,
+    /// Optional request body.
+    pub body: Option<Vec<u8>>,
+    /// Additional request headers.
+    pub headers: Vec<(String, String)>,
 }
 
-impl Driver for HttpDriver {
-	#[cfg(feature = "std")]
-    async fn execute(&self, command: Command) -> CommandResult {
-        let command_id = command.id.clone();
-        let rs = self.dvc.resources.get(&command.resource);
-        let endpoint = match &self.dvc.endpoint {
-            DeviceEndpoint::Http { url } => url,
-            _ => "",
-        };
-        let tcp_stream = TcpStream::connect(endpoint)
-            .map_err(|e| format!("Failed to connect: {}", e))
-            .unwrap();
-        match rs {
-            Some(resource) => {
-                let res = handler::send_request(
-                    &tcp_stream,
-                    &match &self.dvc.endpoint {
-                        DeviceEndpoint::Http { url } => url,
-                        _ => "",
-                    },
-                    &resource.resource_attributes,
-                )
-                .map_err(|e| e.to_string());
-                CommandResult {
-                    command_id,
-                    device_id: self.dvc.id.clone(),
-                    res: res,
-                }
+/// Native HTTP response returned by the HTTP protocol adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpResponse {
+    /// Raw response bytes returned from server.
+    pub body: Vec<u8>,
+}
+
+/// Conversion error raised when routed command cannot be represented as HTTP request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HttpCommandConversionError {
+    /// Routed command intent cannot be executed via HTTP request/response semantics.
+    UnsupportedIntent,
+    /// Target resource does not exist on concrete device definition.
+    UnknownResource(String),
+}
+
+impl core::fmt::Display for HttpCommandConversionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnsupportedIntent => write!(f, "unsupported intent for HTTP driver"),
+            Self::UnknownResource(resource) => {
+                write!(f, "resource {resource} not found for HTTP driver")
             }
-            None => CommandResult {
-                command_id,
-                device_id: self.dvc.id.clone(),
-                res: Err(format!("Resource {} not found", command.resource)),
-            },
         }
     }
+}
 
-    async fn start(&self) -> Result<(), String> {
-        // no initialization needed for HTTP driver
+/// HTTP protocol adapter implementing lifecycle and request/response capabilities.
+#[derive(Debug, Clone)]
+pub struct HttpDriver {
+    /// Device metadata and resource map served by this driver.
+    pub dvc: Device<attributes::HttpResourceAttributes>,
+}
+
+impl HttpDriver {
+    /// Builds a concrete HTTP request from routed command and device resource metadata.
+    pub fn try_request_from_command(
+        &self,
+        command: &Command,
+    ) -> Result<HttpRequest, HttpCommandConversionError> {
+        match &command.intent {
+            Intent::Read { resource } | Intent::Invoke { operation: resource, .. } => self
+                .dvc
+                .resources
+                .get(resource)
+                .map(|resource| HttpRequest {
+                    method: resource.resource_attributes.method.clone(),
+                    path: resource.resource_attributes.slug.clone(),
+                    body: None,
+                    headers: resource
+                        .resource_attributes
+                        .headers
+                        .clone()
+                        .unwrap_or_default(),
+                })
+                .ok_or_else(|| HttpCommandConversionError::UnknownResource(resource.clone())),
+            Intent::Write { resource, payload } => self
+                .dvc
+                .resources
+                .get(resource)
+                .map(|resource| HttpRequest {
+                    method: resource.resource_attributes.method.clone(),
+                    path: resource.resource_attributes.slug.clone(),
+                    body: Some(payload.clone()),
+                    headers: resource
+                        .resource_attributes
+                        .headers
+                        .clone()
+                        .unwrap_or_default(),
+                })
+                .ok_or_else(|| HttpCommandConversionError::UnknownResource(resource.clone())),
+            Intent::Send { .. } | Intent::Subscribe { .. } | Intent::Unsubscribe { .. } => {
+                Err(HttpCommandConversionError::UnsupportedIntent)
+            }
+        }
+    }
+}
+
+impl Lifecycle for HttpDriver {
+    type Error = String;
+
+    async fn start(&self) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    async fn stop(&self) -> Result<(), String> {
-        // no cleanup needed for HTTP driver
+    async fn stop(&self) -> Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+impl RequestResponse for HttpDriver {
+    type Request = HttpRequest;
+    type Response = HttpResponse;
+    type Error = String;
+
+    #[cfg(feature = "std")]
+    async fn execute(&self, request: Self::Request) -> Result<Self::Response, Self::Error> {
+        let endpoint = match &self.dvc.endpoint {
+            DeviceEndpoint::Http(config) => config.url.as_str(),
+            _ => return Err("device endpoint is not HTTP".to_string()),
+        };
+
+        handler::send_request(endpoint, &request)
+            .map(|body| HttpResponse { body })
+            .map_err(|e| e.to_string())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn execute(&self, _request: Self::Request) -> Result<Self::Response, Self::Error> {
+        Err("HTTP driver not implemented for no_std environment".to_string())
     }
 }

--- a/crates/ferredge-proto-http/src/lib.rs
+++ b/crates/ferredge-proto-http/src/lib.rs
@@ -2,7 +2,10 @@
 
 extern crate alloc;
 
-use alloc::{string::{String, ToString}, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use ferredge_core::prelude::*;
 
@@ -22,7 +25,9 @@ mod runtime_stack {
 }
 #[cfg(feature = "async-std-runtime")]
 mod runtime_stack {
-    pub use ferredge_runtime_async_std::{AsyncStdNet as StackNet, AsyncStdRuntime as StackRuntime};
+    pub use ferredge_runtime_async_std::{
+        AsyncStdNet as StackNet, AsyncStdRuntime as StackRuntime,
+    };
 }
 #[cfg(feature = "embassy-runtime")]
 mod runtime_stack {
@@ -140,7 +145,11 @@ impl TryFrom<HttpCommandRef<'_>> for HttpRequest {
 
     fn try_from(value: HttpCommandRef<'_>) -> Result<Self, Self::Error> {
         match &value.command.intent {
-            Intent::Read { resource } | Intent::Invoke { operation: resource, .. } => value
+            Intent::Read { resource }
+            | Intent::Invoke {
+                operation: resource,
+                ..
+            } => value
                 .device
                 .resources
                 .get(resource)
@@ -255,17 +264,17 @@ mod tests {
         );
 
         HttpDriver::new(Device {
-                id: "device-1".to_string(),
-                name: "HTTP Device".to_string(),
-                status: DeviceStatus::Online,
-                endpoint: DeviceEndpoint::http(HttpEndpointConfig {
-                    url: "127.0.0.1:8080".to_string(),
-                }),
-                metadata: None,
-                max_connections: Some(4),
-                resources,
-                message_endpoints: Vec::new(),
-            })
+            id: "device-1".to_string(),
+            name: "HTTP Device".to_string(),
+            status: DeviceStatus::Online,
+            endpoint: DeviceEndpoint::http(HttpEndpointConfig {
+                url: "127.0.0.1:8080".to_string(),
+            }),
+            metadata: None,
+            max_connections: Some(4),
+            resources,
+            message_endpoints: Vec::new(),
+        })
     }
 
     #[test]

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -24,3 +24,4 @@ ferredge-runtime-async-std = { workspace = true, optional = true }
 ferredge-runtime-embassy = { workspace = true, optional = true }
 
 [dev-dependencies]
+ferredge-proto-http = { workspace = true }

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
+# `std` enables the live TCP MQTT runtime. Without it, the crate remains available for
+# conversion into MQTT-native packets but transport operations are not available.
 default = ["std"]
 std = ["ferredge-core/std", "mqtt_protocol_core/std", "serde/std"]
 

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -18,8 +18,8 @@ mosquitto-tests = []
 
 [dependencies]
 ferredge-core = { workspace = true }
-mqtt_protocol_core = { workspace = true }
 serde = { workspace = true }
+mqtt_protocol_core = { package = "mqtt-protocol-core", version = "0.7.7", default-features = false }
 ferredge-runtime-tokio = { workspace = true, optional = true }
 ferredge-runtime-async-std = { workspace = true, optional = true }
 ferredge-runtime-embassy = { workspace = true, optional = true }

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -14,6 +14,7 @@ std = ["ferredge-core/std", "mqtt_protocol_core/std", "serde/std"]
 tokio-runtime = ["std", "dep:ferredge-runtime-tokio"]
 async-std-runtime = ["std", "dep:ferredge-runtime-async-std"]
 embassy-runtime = ["dep:ferredge-runtime-embassy"]
+mosquitto-tests = []
 
 [dependencies]
 ferredge-core = { workspace = true }

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -8,14 +8,19 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-# `std` enables the live TCP MQTT runtime. Without it, the crate remains available for
-# conversion into MQTT-native packets but transport operations are not available.
-default = ["std"]
+# `std` enables common std support. Runtime stack selection happens via stack-specific features.
+default = ["tokio-runtime"]
 std = ["ferredge-core/std", "mqtt_protocol_core/std", "serde/std"]
+tokio-runtime = ["std", "dep:ferredge-runtime-tokio"]
+async-std-runtime = ["std", "dep:ferredge-runtime-async-std"]
+embassy-runtime = ["dep:ferredge-runtime-embassy"]
 
 [dependencies]
 ferredge-core = { workspace = true }
 mqtt_protocol_core = { workspace = true }
 serde = { workspace = true }
+ferredge-runtime-tokio = { workspace = true, optional = true }
+ferredge-runtime-async-std = { workspace = true, optional = true }
+ferredge-runtime-embassy = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/ferredge-proto-mqtt/Cargo.toml
+++ b/crates/ferredge-proto-mqtt/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ferredge-proto-mqtt"
+description = "MQTT protocol support for ferredge - device and data aggregator for edge devices"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[features]
+default = ["std"]
+std = ["ferredge-core/std", "mqtt_protocol_core/std", "serde/std"]
+
+[dependencies]
+ferredge-core = { workspace = true }
+mqtt_protocol_core = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -229,7 +229,15 @@ pub fn build_v5_publish_props(
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
         ));
     }
-    if let Some(correlation_id) = &publish.correlation_id {
+    if let Some(correlation_id) = publish
+        .correlation_id
+        .as_ref()
+        .or(if publish.reply_to.is_some() {
+            Some(&publish.command_id)
+        } else {
+            None
+        })
+    {
         props.push(mqtt::packet::Property::CorrelationData(
             mqtt::packet::CorrelationData::new(correlation_id.as_bytes().to_vec())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -27,15 +27,29 @@ impl TryFrom<&Command> for MqttPublishRequest {
                 channel,
                 payload,
                 options,
-            } => Ok(Self {
+            } => {
+                let mqtt = match &options.protocol {
+                    Some(BrokerMessageProtocolOptions::Mqtt(mqtt)) => mqtt.clone(),
+                    None => MqttMessageOptions::default(),
+                };
+                Ok(Self {
                 command_id: command.id.clone(),
                 channel: channel.clone(),
                 payload: payload.clone(),
                 delivery: options.delivery,
+                retain: mqtt.retain,
+                payload_format: mqtt.payload_format,
+                content_type: mqtt.content_type,
+                message_expiry_interval_secs: mqtt.message_expiry_interval_secs,
+                topic_alias: mqtt.topic_alias,
                 headers: options.headers.clone(),
+                user_properties: mqtt.user_properties,
                 reply_to: options.reply_to.clone(),
+                response_topic: mqtt.response_topic,
                 correlation_id: options.correlation_id.clone(),
-            }),
+                correlation_data: mqtt.correlation_data,
+            })
+            }
             _ => Err(MqttCommandConversionError::UnsupportedIntent),
         }
     }
@@ -46,19 +60,35 @@ impl TryFrom<&Command> for MqttSubscriptionRequest {
 
     fn try_from(command: &Command) -> Result<Self, Self::Error> {
         match &command.intent {
-            Intent::Subscribe { channel, options } => Ok(Self {
+            Intent::Subscribe { channel, options } => {
+                let mqtt = match &options.protocol {
+                    Some(BrokerSubscriptionProtocolOptions::Mqtt(mqtt)) => mqtt.clone(),
+                    None => MqttSubscriptionOptions::default(),
+                };
+                Ok(Self {
                 command_id: command.id.clone(),
                 channel: channel.clone(),
                 delivery: options.delivery,
                 durable_name: options.durable_name.clone(),
                 shared_group: options.shared_group.clone(),
-            }),
+                no_local: mqtt.no_local,
+                retain_as_published: mqtt.retain_as_published,
+                retain_handling: mqtt.retain_handling,
+                subscription_identifier: mqtt.subscription_identifier,
+                user_properties: mqtt.user_properties,
+            })
+            }
             Intent::Unsubscribe { channel } => Ok(Self {
                 command_id: command.id.clone(),
                 channel: channel.clone(),
                 delivery: None,
                 durable_name: None,
                 shared_group: None,
+                no_local: false,
+                retain_as_published: false,
+                retain_handling: None,
+                subscription_identifier: None,
+                user_properties: Vec::new(),
             }),
             _ => Err(MqttCommandConversionError::UnsupportedIntent),
         }
@@ -112,6 +142,7 @@ pub fn build_publish_packet(
                 .topic_name(topic.as_str())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
                 .qos(qos)
+                .retain(publish.retain)
                 .payload(publish.payload)
                 .props(props);
             if let Some(packet_id) = packet_id {
@@ -126,10 +157,12 @@ pub fn build_publish_packet(
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
         }
         MqttProtocolVersion::V3_1_1 => {
+            validate_v3_publish_support(&publish)?;
             let mut builder = mqtt::packet::v3_1_1::Publish::builder()
                 .topic_name(topic.as_str())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
                 .qos(qos)
+                .retain(publish.retain)
                 .payload(publish.payload);
             if let Some(packet_id) = packet_id {
                 builder = builder.packet_id(packet_id);
@@ -150,11 +183,14 @@ pub fn build_subscribe_packet(
     version: MqttProtocolVersion,
 ) -> Result<MqttPacketRequest, MqttCommandConversionError> {
     let subscription = MqttSubscriptionRequest::try_from(command)?;
-    let topic = mqtt_topic_from_address(&subscription.channel)?;
-    let entry = mqtt::packet::SubEntry::new(
-        topic.as_str(),
-        mqtt::packet::SubOpts::new().set_qos(qos_from_delivery(subscription.delivery)),
-    )
+    let topic = mqtt_topic_from_subscription(&subscription)?;
+    let mut sub_opts = mqtt::packet::SubOpts::new().set_qos(qos_from_delivery(subscription.delivery));
+    sub_opts = sub_opts.set_nl(subscription.no_local);
+    sub_opts = sub_opts.set_rap(subscription.retain_as_published);
+    if let Some(retain_handling) = subscription.retain_handling {
+        sub_opts = sub_opts.set_rh(retain_handling_from_core(retain_handling));
+    }
+    let entry = mqtt::packet::SubEntry::new(topic.as_str(), sub_opts)
     .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?;
 
     match version {
@@ -171,15 +207,18 @@ pub fn build_subscribe_packet(
                 })
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
         }
-        MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Subscribe::builder()
-            .packet_id(1u16)
-            .entries(vec![entry])
-            .build()
-            .map(|packet| MqttPacketRequest {
-                command_id: subscription.command_id.clone(),
-                packet: MqttWirePacket::V3Subscribe(packet),
-            })
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V3_1_1 => {
+            validate_v3_subscribe_support(&subscription)?;
+            mqtt::packet::v3_1_1::Subscribe::builder()
+                .packet_id(1u16)
+                .entries(vec![entry])
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: subscription.command_id.clone(),
+                    packet: MqttWirePacket::V3Subscribe(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
     }
 }
 
@@ -188,7 +227,7 @@ pub fn build_unsubscribe_packet(
     version: MqttProtocolVersion,
 ) -> Result<MqttPacketRequest, MqttCommandConversionError> {
     let subscription = MqttSubscriptionRequest::try_from(command)?;
-    let topic = mqtt_topic_from_address(&subscription.channel)?;
+    let topic = mqtt_topic_from_subscription(&subscription)?;
 
     match version {
         MqttProtocolVersion::V5_0 => {
@@ -205,16 +244,19 @@ pub fn build_unsubscribe_packet(
                 })
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
         }
-        MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Unsubscribe::builder()
-            .packet_id(1u16)
-            .entries(vec![topic.as_str()])
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
-            .build()
-            .map(|packet| MqttPacketRequest {
-                command_id: subscription.command_id,
-                packet: MqttWirePacket::V3Unsubscribe(packet),
-            })
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V3_1_1 => {
+            validate_v3_subscribe_support(&subscription)?;
+            mqtt::packet::v3_1_1::Unsubscribe::builder()
+                .packet_id(1u16)
+                .entries(vec![topic.as_str()])
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: subscription.command_id,
+                    packet: MqttWirePacket::V3Unsubscribe(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
     }
 }
 
@@ -223,39 +265,74 @@ pub fn build_v5_publish_props(
 ) -> Result<mqtt::packet::Properties, MqttCommandConversionError> {
     let mut props = mqtt::packet::Properties::new();
 
-    if let Some(reply_to) = &publish.reply_to {
+    if let Some(payload_format) = publish.payload_format {
+        props.push(mqtt::packet::Property::PayloadFormatIndicator(
+            mqtt::packet::PayloadFormatIndicator::new(match payload_format {
+                MqttPayloadFormat::Bytes => mqtt::packet::PayloadFormat::Binary,
+                MqttPayloadFormat::Utf8 => mqtt::packet::PayloadFormat::String,
+            })
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+    if let Some(expiry) = publish.message_expiry_interval_secs {
+        props.push(mqtt::packet::Property::MessageExpiryInterval(
+            mqtt::packet::MessageExpiryInterval::new(expiry)
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+    if let Some(topic_alias) = publish.topic_alias {
+        props.push(mqtt::packet::Property::TopicAlias(
+            mqtt::packet::TopicAlias::new(topic_alias)
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+
+    if let Some(reply_to) = publish.response_topic.as_ref().or(publish.reply_to.as_ref()) {
         props.push(mqtt::packet::Property::ResponseTopic(
             mqtt::packet::ResponseTopic::new(reply_to.as_str())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
         ));
     }
-    if let Some(correlation_id) = publish
-        .correlation_id
-        .as_ref()
-        .or(if publish.reply_to.is_some() {
-            Some(&publish.command_id)
-        } else {
-            None
-        })
-    {
+    if let Some(content_type) = &publish.content_type {
+        props.push(mqtt::packet::Property::ContentType(
+            mqtt::packet::ContentType::new(content_type.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+
+    let correlation_data = publish.correlation_data.clone().or_else(|| {
+        publish
+            .correlation_id
+            .as_ref()
+            .map(|value| value.as_bytes().to_vec())
+            .or_else(|| {
+                if publish.reply_to.is_some() || publish.response_topic.is_some() {
+                    Some(publish.command_id.as_bytes().to_vec())
+                } else {
+                    None
+                }
+            })
+    });
+    if let Some(correlation_data) = correlation_data {
         props.push(mqtt::packet::Property::CorrelationData(
-            mqtt::packet::CorrelationData::new(correlation_id.as_bytes().to_vec())
+            mqtt::packet::CorrelationData::new(correlation_data)
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
         ));
     }
 
     for (key, value) in &publish.headers {
-        if key.eq_ignore_ascii_case("content-type") {
-            props.push(mqtt::packet::Property::ContentType(
-                mqtt::packet::ContentType::new(value.as_str())
-                    .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
-            ));
-        } else {
+        if !key.eq_ignore_ascii_case("content-type") {
             props.push(mqtt::packet::Property::UserProperty(
                 mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
                     .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
             ));
         }
+    }
+    for (key, value) in &publish.user_properties {
+        props.push(mqtt::packet::Property::UserProperty(
+            mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
     }
 
     Ok(props)
@@ -266,22 +343,15 @@ pub fn build_v5_subscribe_props(
 ) -> Result<mqtt::packet::Properties, MqttCommandConversionError> {
     let mut props = mqtt::packet::Properties::new();
 
-    if subscription.durable_name.is_some() || subscription.shared_group.is_some() {
+    if let Some(subscription_identifier) = subscription.subscription_identifier {
         props.push(mqtt::packet::Property::SubscriptionIdentifier(
-            mqtt::packet::SubscriptionIdentifier::new(1)
+            mqtt::packet::SubscriptionIdentifier::new(subscription_identifier)
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
         ));
     }
-
-    if let Some(durable_name) = &subscription.durable_name {
+    for (key, value) in &subscription.user_properties {
         props.push(mqtt::packet::Property::UserProperty(
-            mqtt::packet::UserProperty::new("ferredge-durable-name", durable_name.as_str())
-                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
-        ));
-    }
-    if let Some(shared_group) = &subscription.shared_group {
-        props.push(mqtt::packet::Property::UserProperty(
-            mqtt::packet::UserProperty::new("ferredge-shared-group", shared_group.as_str())
+            mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
         ));
     }
@@ -311,4 +381,67 @@ pub fn mqtt_topic_from_address(
             Err(MqttCommandConversionError::UnsupportedChannelKind)
         }
     }
+}
+
+fn mqtt_topic_from_subscription(
+    subscription: &MqttSubscriptionRequest,
+) -> Result<String, MqttCommandConversionError> {
+    let topic = mqtt_topic_from_address(&subscription.channel)?;
+    if let Some(shared_group) = &subscription.shared_group {
+        Ok(format!("$share/{shared_group}/{topic}"))
+    } else {
+        Ok(topic)
+    }
+}
+
+fn retain_handling_from_core(
+    value: MqttRetainHandling,
+) -> mqtt::packet::RetainHandling {
+    match value {
+        MqttRetainHandling::SendRetained => mqtt::packet::RetainHandling::SendRetained,
+        MqttRetainHandling::SendRetainedIfNotExists => {
+            mqtt::packet::RetainHandling::SendRetainedIfNotExists
+        }
+        MqttRetainHandling::DoNotSendRetained => {
+            mqtt::packet::RetainHandling::DoNotSendRetained
+        }
+    }
+}
+
+fn validate_v3_publish_support(
+    publish: &MqttPublishRequest,
+) -> Result<(), MqttCommandConversionError> {
+    if publish.payload_format.is_some()
+        || publish.content_type.is_some()
+        || publish.message_expiry_interval_secs.is_some()
+        || publish.topic_alias.is_some()
+        || publish.response_topic.is_some()
+        || publish.correlation_data.is_some()
+        || !publish.user_properties.is_empty()
+        || !publish.headers.is_empty()
+        || publish.reply_to.is_some()
+        || publish.correlation_id.is_some()
+    {
+        return Err(MqttCommandConversionError::InvalidCommand(
+            "MQTT 3.1.1 publish does not support MQTT v5 properties".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_v3_subscribe_support(
+    subscription: &MqttSubscriptionRequest,
+) -> Result<(), MqttCommandConversionError> {
+    if subscription.no_local
+        || subscription.retain_as_published
+        || subscription.retain_handling.is_some()
+        || subscription.subscription_identifier.is_some()
+        || !subscription.user_properties.is_empty()
+        || subscription.durable_name.is_some()
+    {
+        return Err(MqttCommandConversionError::InvalidCommand(
+            "MQTT 3.1.1 subscribe does not support requested MQTT v5 subscription options".to_string(),
+        ));
+    }
+    Ok(())
 }

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -2,10 +2,13 @@
 extern crate alloc;
 
 #[cfg(feature = "std")]
-use std::string::String;
+use std::string::{String, ToString};
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
 use ferredge_core::prelude::*;
 use mqtt_protocol_core::mqtt;

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -158,15 +158,19 @@ pub fn build_subscribe_packet(
     .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?;
 
     match version {
-        MqttProtocolVersion::V5_0 => mqtt::packet::v5_0::Subscribe::builder()
-            .packet_id(1u16)
-            .entries(vec![entry])
-            .build()
-            .map(|packet| MqttPacketRequest {
-                command_id: subscription.command_id.clone(),
-                packet: MqttWirePacket::V5Subscribe(packet),
-            })
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V5_0 => {
+            let props = build_v5_subscribe_props(&subscription)?;
+            mqtt::packet::v5_0::Subscribe::builder()
+                .packet_id(1u16)
+                .entries(vec![entry])
+                .props(props)
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: subscription.command_id.clone(),
+                    packet: MqttWirePacket::V5Subscribe(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
         MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Subscribe::builder()
             .packet_id(1u16)
             .entries(vec![entry])
@@ -187,16 +191,20 @@ pub fn build_unsubscribe_packet(
     let topic = mqtt_topic_from_address(&subscription.channel)?;
 
     match version {
-        MqttProtocolVersion::V5_0 => mqtt::packet::v5_0::Unsubscribe::builder()
-            .packet_id(1u16)
-            .entries(vec![topic.as_str()])
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
-            .build()
-            .map(|packet| MqttPacketRequest {
-                command_id: subscription.command_id.clone(),
-                packet: MqttWirePacket::V5Unsubscribe(packet),
-            })
-            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V5_0 => {
+            let props = build_v5_unsubscribe_props(&subscription)?;
+            mqtt::packet::v5_0::Unsubscribe::builder()
+                .packet_id(1u16)
+                .entries(vec![topic.as_str()])
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+                .props(props)
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: subscription.command_id.clone(),
+                    packet: MqttWirePacket::V5Unsubscribe(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
         MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Unsubscribe::builder()
             .packet_id(1u16)
             .entries(vec![topic.as_str()])
@@ -242,6 +250,45 @@ pub fn build_v5_publish_props(
         }
     }
 
+    Ok(props)
+}
+
+pub fn build_v5_subscribe_props(
+    subscription: &MqttSubscriptionRequest,
+) -> Result<mqtt::packet::Properties, MqttCommandConversionError> {
+    let mut props = mqtt::packet::Properties::new();
+
+    if subscription.durable_name.is_some() || subscription.shared_group.is_some() {
+        props.push(mqtt::packet::Property::SubscriptionIdentifier(
+            mqtt::packet::SubscriptionIdentifier::new(1)
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+
+    if let Some(durable_name) = &subscription.durable_name {
+        props.push(mqtt::packet::Property::UserProperty(
+            mqtt::packet::UserProperty::new("ferredge-durable-name", durable_name.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+    if let Some(shared_group) = &subscription.shared_group {
+        props.push(mqtt::packet::Property::UserProperty(
+            mqtt::packet::UserProperty::new("ferredge-shared-group", shared_group.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+
+    Ok(props)
+}
+
+pub fn build_v5_unsubscribe_props(
+    subscription: &MqttSubscriptionRequest,
+) -> Result<mqtt::packet::Properties, MqttCommandConversionError> {
+    let mut props = mqtt::packet::Properties::new();
+    props.push(mqtt::packet::Property::UserProperty(
+        mqtt::packet::UserProperty::new("ferredge-command-id", subscription.command_id.as_str())
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+    ));
     Ok(props)
 }
 

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -1,0 +1,256 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::string::String;
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use ferredge_core::prelude::*;
+use mqtt_protocol_core::mqtt;
+
+use crate::types::{
+    MqttCommandConversionError, MqttCommandRef, MqttPacketRequest, MqttPublishRequest,
+    MqttSubscriptionRequest, MqttWirePacket,
+};
+
+impl TryFrom<&Command> for MqttPublishRequest {
+    type Error = MqttCommandConversionError;
+
+    fn try_from(command: &Command) -> Result<Self, Self::Error> {
+        match &command.intent {
+            Intent::Send {
+                channel,
+                payload,
+                options,
+            } => Ok(Self {
+                command_id: command.id.clone(),
+                channel: channel.clone(),
+                payload: payload.clone(),
+                delivery: options.delivery,
+                headers: options.headers.clone(),
+                reply_to: options.reply_to.clone(),
+                correlation_id: options.correlation_id.clone(),
+            }),
+            _ => Err(MqttCommandConversionError::UnsupportedIntent),
+        }
+    }
+}
+
+impl TryFrom<&Command> for MqttSubscriptionRequest {
+    type Error = MqttCommandConversionError;
+
+    fn try_from(command: &Command) -> Result<Self, Self::Error> {
+        match &command.intent {
+            Intent::Subscribe { channel, options } => Ok(Self {
+                command_id: command.id.clone(),
+                channel: channel.clone(),
+                delivery: options.delivery,
+                durable_name: options.durable_name.clone(),
+                shared_group: options.shared_group.clone(),
+            }),
+            Intent::Unsubscribe { channel } => Ok(Self {
+                command_id: command.id.clone(),
+                channel: channel.clone(),
+                delivery: None,
+                durable_name: None,
+                shared_group: None,
+            }),
+            _ => Err(MqttCommandConversionError::UnsupportedIntent),
+        }
+    }
+}
+
+impl TryFrom<MqttCommandRef<'_>> for MqttPacketRequest {
+    type Error = MqttCommandConversionError;
+
+    fn try_from(value: MqttCommandRef<'_>) -> Result<Self, Self::Error> {
+        let config = value.endpoint_config()?;
+        let version = config.preferred_protocol_version();
+
+        match &value.command.intent {
+            Intent::Send { .. } => build_publish_packet(value.command, version),
+            Intent::Subscribe { .. } => build_subscribe_packet(value.command, version),
+            Intent::Unsubscribe { .. } => build_unsubscribe_packet(value.command, version),
+            _ => Err(MqttCommandConversionError::UnsupportedIntent),
+        }
+    }
+}
+
+pub fn qos_from_delivery(delivery: Option<DeliveryGuarantee>) -> mqtt::packet::Qos {
+    match delivery {
+        Some(DeliveryGuarantee::ExactlyOnce) => mqtt::packet::Qos::ExactlyOnce,
+        Some(DeliveryGuarantee::AtLeastOnce) => mqtt::packet::Qos::AtLeastOnce,
+        _ => mqtt::packet::Qos::AtMostOnce,
+    }
+}
+
+pub fn packet_id_for_qos(qos: mqtt::packet::Qos) -> Option<u16> {
+    match qos {
+        mqtt::packet::Qos::AtMostOnce => None,
+        mqtt::packet::Qos::AtLeastOnce | mqtt::packet::Qos::ExactlyOnce => Some(1u16),
+    }
+}
+
+pub fn build_publish_packet(
+    command: &Command,
+    version: MqttProtocolVersion,
+) -> Result<MqttPacketRequest, MqttCommandConversionError> {
+    let publish = MqttPublishRequest::try_from(command)?;
+    let topic = mqtt_topic_from_address(&publish.channel)?;
+    let qos = qos_from_delivery(publish.delivery);
+    let packet_id = packet_id_for_qos(qos);
+
+    match version {
+        MqttProtocolVersion::V5_0 => {
+            let props = build_v5_publish_props(&publish)?;
+            let mut builder = mqtt::packet::v5_0::Publish::builder()
+                .topic_name(topic.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+                .qos(qos)
+                .payload(publish.payload)
+                .props(props);
+            if let Some(packet_id) = packet_id {
+                builder = builder.packet_id(packet_id);
+            }
+            builder
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: publish.command_id,
+                    packet: MqttWirePacket::V5Publish(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
+        MqttProtocolVersion::V3_1_1 => {
+            let mut builder = mqtt::packet::v3_1_1::Publish::builder()
+                .topic_name(topic.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+                .qos(qos)
+                .payload(publish.payload);
+            if let Some(packet_id) = packet_id {
+                builder = builder.packet_id(packet_id);
+            }
+            builder
+                .build()
+                .map(|packet| MqttPacketRequest {
+                    command_id: publish.command_id,
+                    packet: MqttWirePacket::V3Publish(packet),
+                })
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))
+        }
+    }
+}
+
+pub fn build_subscribe_packet(
+    command: &Command,
+    version: MqttProtocolVersion,
+) -> Result<MqttPacketRequest, MqttCommandConversionError> {
+    let subscription = MqttSubscriptionRequest::try_from(command)?;
+    let topic = mqtt_topic_from_address(&subscription.channel)?;
+    let entry = mqtt::packet::SubEntry::new(
+        topic.as_str(),
+        mqtt::packet::SubOpts::new().set_qos(qos_from_delivery(subscription.delivery)),
+    )
+    .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?;
+
+    match version {
+        MqttProtocolVersion::V5_0 => mqtt::packet::v5_0::Subscribe::builder()
+            .packet_id(1u16)
+            .entries(vec![entry])
+            .build()
+            .map(|packet| MqttPacketRequest {
+                command_id: subscription.command_id.clone(),
+                packet: MqttWirePacket::V5Subscribe(packet),
+            })
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Subscribe::builder()
+            .packet_id(1u16)
+            .entries(vec![entry])
+            .build()
+            .map(|packet| MqttPacketRequest {
+                command_id: subscription.command_id.clone(),
+                packet: MqttWirePacket::V3Subscribe(packet),
+            })
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+    }
+}
+
+pub fn build_unsubscribe_packet(
+    command: &Command,
+    version: MqttProtocolVersion,
+) -> Result<MqttPacketRequest, MqttCommandConversionError> {
+    let subscription = MqttSubscriptionRequest::try_from(command)?;
+    let topic = mqtt_topic_from_address(&subscription.channel)?;
+
+    match version {
+        MqttProtocolVersion::V5_0 => mqtt::packet::v5_0::Unsubscribe::builder()
+            .packet_id(1u16)
+            .entries(vec![topic.as_str()])
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+            .build()
+            .map(|packet| MqttPacketRequest {
+                command_id: subscription.command_id.clone(),
+                packet: MqttWirePacket::V5Unsubscribe(packet),
+            })
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+        MqttProtocolVersion::V3_1_1 => mqtt::packet::v3_1_1::Unsubscribe::builder()
+            .packet_id(1u16)
+            .entries(vec![topic.as_str()])
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?
+            .build()
+            .map(|packet| MqttPacketRequest {
+                command_id: subscription.command_id,
+                packet: MqttWirePacket::V3Unsubscribe(packet),
+            })
+            .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string())),
+    }
+}
+
+pub fn build_v5_publish_props(
+    publish: &MqttPublishRequest,
+) -> Result<mqtt::packet::Properties, MqttCommandConversionError> {
+    let mut props = mqtt::packet::Properties::new();
+
+    if let Some(reply_to) = &publish.reply_to {
+        props.push(mqtt::packet::Property::ResponseTopic(
+            mqtt::packet::ResponseTopic::new(reply_to.as_str())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+    if let Some(correlation_id) = &publish.correlation_id {
+        props.push(mqtt::packet::Property::CorrelationData(
+            mqtt::packet::CorrelationData::new(correlation_id.as_bytes().to_vec())
+                .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+        ));
+    }
+
+    for (key, value) in &publish.headers {
+        if key.eq_ignore_ascii_case("content-type") {
+            props.push(mqtt::packet::Property::ContentType(
+                mqtt::packet::ContentType::new(value.as_str())
+                    .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+            ));
+        } else {
+            props.push(mqtt::packet::Property::UserProperty(
+                mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
+                    .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
+            ));
+        }
+    }
+
+    Ok(props)
+}
+
+pub fn mqtt_topic_from_address(
+    value: &BrokerAddress,
+) -> Result<String, MqttCommandConversionError> {
+    match value.kind {
+        None | Some(BrokerChannelKind::Topic) | Some(BrokerChannelKind::Subject) => {
+            Ok(value.name.clone())
+        }
+        Some(BrokerChannelKind::Queue) | Some(BrokerChannelKind::Stream) => {
+            Err(MqttCommandConversionError::UnsupportedChannelKind)
+        }
+    }
+}

--- a/crates/ferredge-proto-mqtt/src/convert.rs
+++ b/crates/ferredge-proto-mqtt/src/convert.rs
@@ -33,22 +33,22 @@ impl TryFrom<&Command> for MqttPublishRequest {
                     None => MqttMessageOptions::default(),
                 };
                 Ok(Self {
-                command_id: command.id.clone(),
-                channel: channel.clone(),
-                payload: payload.clone(),
-                delivery: options.delivery,
-                retain: mqtt.retain,
-                payload_format: mqtt.payload_format,
-                content_type: mqtt.content_type,
-                message_expiry_interval_secs: mqtt.message_expiry_interval_secs,
-                topic_alias: mqtt.topic_alias,
-                headers: options.headers.clone(),
-                user_properties: mqtt.user_properties,
-                reply_to: options.reply_to.clone(),
-                response_topic: mqtt.response_topic,
-                correlation_id: options.correlation_id.clone(),
-                correlation_data: mqtt.correlation_data,
-            })
+                    command_id: command.id.clone(),
+                    channel: channel.clone(),
+                    payload: payload.clone(),
+                    delivery: options.delivery,
+                    retain: mqtt.retain,
+                    payload_format: mqtt.payload_format,
+                    content_type: mqtt.content_type,
+                    message_expiry_interval_secs: mqtt.message_expiry_interval_secs,
+                    topic_alias: mqtt.topic_alias,
+                    headers: options.headers.clone(),
+                    user_properties: mqtt.user_properties,
+                    reply_to: options.reply_to.clone(),
+                    response_topic: mqtt.response_topic,
+                    correlation_id: options.correlation_id.clone(),
+                    correlation_data: mqtt.correlation_data,
+                })
             }
             _ => Err(MqttCommandConversionError::UnsupportedIntent),
         }
@@ -66,17 +66,17 @@ impl TryFrom<&Command> for MqttSubscriptionRequest {
                     None => MqttSubscriptionOptions::default(),
                 };
                 Ok(Self {
-                command_id: command.id.clone(),
-                channel: channel.clone(),
-                delivery: options.delivery,
-                durable_name: options.durable_name.clone(),
-                shared_group: options.shared_group.clone(),
-                no_local: mqtt.no_local,
-                retain_as_published: mqtt.retain_as_published,
-                retain_handling: mqtt.retain_handling,
-                subscription_identifier: mqtt.subscription_identifier,
-                user_properties: mqtt.user_properties,
-            })
+                    command_id: command.id.clone(),
+                    channel: channel.clone(),
+                    delivery: options.delivery,
+                    durable_name: options.durable_name.clone(),
+                    shared_group: options.shared_group.clone(),
+                    no_local: mqtt.no_local,
+                    retain_as_published: mqtt.retain_as_published,
+                    retain_handling: mqtt.retain_handling,
+                    subscription_identifier: mqtt.subscription_identifier,
+                    user_properties: mqtt.user_properties,
+                })
             }
             Intent::Unsubscribe { channel } => Ok(Self {
                 command_id: command.id.clone(),
@@ -184,14 +184,15 @@ pub fn build_subscribe_packet(
 ) -> Result<MqttPacketRequest, MqttCommandConversionError> {
     let subscription = MqttSubscriptionRequest::try_from(command)?;
     let topic = mqtt_topic_from_subscription(&subscription)?;
-    let mut sub_opts = mqtt::packet::SubOpts::new().set_qos(qos_from_delivery(subscription.delivery));
+    let mut sub_opts =
+        mqtt::packet::SubOpts::new().set_qos(qos_from_delivery(subscription.delivery));
     sub_opts = sub_opts.set_nl(subscription.no_local);
     sub_opts = sub_opts.set_rap(subscription.retain_as_published);
     if let Some(retain_handling) = subscription.retain_handling {
         sub_opts = sub_opts.set_rh(retain_handling_from_core(retain_handling));
     }
     let entry = mqtt::packet::SubEntry::new(topic.as_str(), sub_opts)
-    .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?;
+        .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?;
 
     match version {
         MqttProtocolVersion::V5_0 => {
@@ -287,7 +288,11 @@ pub fn build_v5_publish_props(
         ));
     }
 
-    if let Some(reply_to) = publish.response_topic.as_ref().or(publish.reply_to.as_ref()) {
+    if let Some(reply_to) = publish
+        .response_topic
+        .as_ref()
+        .or(publish.reply_to.as_ref())
+    {
         props.push(mqtt::packet::Property::ResponseTopic(
             mqtt::packet::ResponseTopic::new(reply_to.as_str())
                 .map_err(|e| MqttCommandConversionError::PacketBuild(e.to_string()))?,
@@ -394,17 +399,13 @@ fn mqtt_topic_from_subscription(
     }
 }
 
-fn retain_handling_from_core(
-    value: MqttRetainHandling,
-) -> mqtt::packet::RetainHandling {
+fn retain_handling_from_core(value: MqttRetainHandling) -> mqtt::packet::RetainHandling {
     match value {
         MqttRetainHandling::SendRetained => mqtt::packet::RetainHandling::SendRetained,
         MqttRetainHandling::SendRetainedIfNotExists => {
             mqtt::packet::RetainHandling::SendRetainedIfNotExists
         }
-        MqttRetainHandling::DoNotSendRetained => {
-            mqtt::packet::RetainHandling::DoNotSendRetained
-        }
+        MqttRetainHandling::DoNotSendRetained => mqtt::packet::RetainHandling::DoNotSendRetained,
     }
 }
 
@@ -440,7 +441,8 @@ fn validate_v3_subscribe_support(
         || subscription.durable_name.is_some()
     {
         return Err(MqttCommandConversionError::InvalidCommand(
-            "MQTT 3.1.1 subscribe does not support requested MQTT v5 subscription options".to_string(),
+            "MQTT 3.1.1 subscribe does not support requested MQTT v5 subscription options"
+                .to_string(),
         ));
     }
     Ok(())

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -206,6 +206,14 @@ impl MqttDriver {
     }
 
     #[cfg(feature = "std")]
+    fn reconnect_config(&self) -> Result<BrokerReconnectConfig, String> {
+        match &self.dvc.endpoint {
+            DeviceEndpoint::Mqtt(config) => Ok(config.reconnect.clone()),
+            _ => Err("device endpoint is not MQTT".to_string()),
+        }
+    }
+
+    #[cfg(feature = "std")]
     fn stop_listener(&self) -> Result<(), String> {
         self.listener_running.store(false, Ordering::SeqCst);
         let mut handle_guard = self
@@ -525,12 +533,14 @@ impl EventSource for MqttDriver {
             let device_id = self.dvc.id.clone();
             let driver = self.clone();
             let runtime = self.runtime.clone();
+            let reconnect = self.reconnect_config()?;
             self.clear_listener_error()?;
             self.broadcast_listener_status(MqttListenerStatus::Running)?;
             let handle = runtime.clone().spawn(async move {
                 let mut sink = sink;
+                let mut reconnect_attempt = 0u32;
 
-                while running.load(Ordering::SeqCst) {
+                'listen: while running.load(Ordering::SeqCst) {
                     let mut session_value = match {
                         let mut guard = match session.lock() {
                             Ok(guard) => guard,
@@ -566,6 +576,7 @@ impl EventSource for MqttDriver {
 
                     match messages {
                         Ok(messages) => {
+                            reconnect_attempt = 0;
                             if let Ok(mut guard) = session.lock() {
                                 *guard = Some(session_value);
                             }
@@ -589,17 +600,44 @@ impl EventSource for MqttDriver {
                                 }
                             }
                         }
-                        Err(error) => {
+                        Err(mut error) => {
                             if let Ok(mut guard) = session.lock() {
                                 *guard = None;
                             }
-                            if running.load(Ordering::SeqCst)
-                                && driver.ensure_connected_async().await.is_ok()
-                            {
-                                if let Ok(mut error_guard) = listener_error.lock() {
-                                    *error_guard = None;
+                            while running.load(Ordering::SeqCst) {
+                                reconnect_attempt = reconnect_attempt.saturating_add(1);
+                                if !reconnect.allows_attempt(reconnect_attempt) {
+                                    break;
                                 }
+
+                                runtime
+                                    .sleep(core::time::Duration::from_millis(
+                                        reconnect.delay_ms_for_attempt(reconnect_attempt),
+                                    ))
+                                    .await;
+
+                                if !running.load(Ordering::SeqCst) {
+                                    break;
+                                }
+
+                                match driver.ensure_connected_async().await {
+                                    Ok(()) => {
+                                        reconnect_attempt = 0;
+                                        if let Ok(mut error_guard) = listener_error.lock() {
+                                            *error_guard = None;
+                                        }
+                                        continue 'listen;
+                                    }
+                                    Err(connect_error) => {
+                                        error = connect_error;
+                                    }
+                                }
+                            }
+                            if reconnect_attempt == 0 && running.load(Ordering::SeqCst) {
                                 continue;
+                            }
+                            if !running.load(Ordering::SeqCst) {
+                                break;
                             }
                             if let Ok(mut error_guard) = listener_error.lock() {
                                 *error_guard = Some(error.clone());

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -4,6 +4,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 use std::sync::{
     atomic::{AtomicBool, Ordering},
+    mpsc,
     Arc, Mutex,
 };
 
@@ -56,6 +57,9 @@ pub struct MqttDriver {
     /// Last background listener failure, if any.
     #[cfg(feature = "std")]
     listener_error: Arc<Mutex<Option<String>>>,
+    /// Subscribers interested in listener status transitions.
+    #[cfg(feature = "std")]
+    listener_status_subscribers: Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
 }
 
 impl core::fmt::Debug for MqttDriver {
@@ -77,6 +81,8 @@ impl MqttDriver {
             listener_handle: Arc::new(Mutex::new(None)),
             #[cfg(feature = "std")]
             listener_error: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "std")]
+            listener_status_subscribers: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -167,6 +173,7 @@ impl MqttDriver {
                 }
             }
         }
+        self.broadcast_listener_status(self.listener_status()?)?;
         Ok(())
     }
 
@@ -187,6 +194,7 @@ impl MqttDriver {
             .lock()
             .map_err(|_| "failed to lock MQTT listener error".to_string())?;
         *guard = None;
+        self.broadcast_listener_status(MqttListenerStatus::Stopped)?;
         Ok(())
     }
 
@@ -201,6 +209,40 @@ impl MqttDriver {
             Some(error) => Ok(MqttListenerStatus::Failed(error)),
             None => Ok(MqttListenerStatus::Stopped),
         }
+    }
+
+    /// Subscribes to background listener status changes for this MQTT driver.
+    #[cfg(feature = "std")]
+    pub fn subscribe_listener_status(&self) -> Result<mpsc::Receiver<MqttListenerStatus>, String> {
+        let (tx, rx) = mpsc::channel();
+        let current = self.listener_status()?;
+        tx.send(current)
+            .map_err(|_| "failed to seed MQTT listener status subscriber".to_string())?;
+        self.listener_status_subscribers
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener subscribers".to_string())?
+            .push(tx);
+        Ok(rx)
+    }
+
+    #[cfg(feature = "std")]
+    fn broadcast_listener_status(&self, status: MqttListenerStatus) -> Result<(), String> {
+        let mut subscribers = self
+            .listener_status_subscribers
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener subscribers".to_string())?;
+        subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+fn broadcast_listener_status_to_subscribers(
+    subscribers: &Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
+    status: MqttListenerStatus,
+) {
+    if let Ok(mut subscribers) = subscribers.lock() {
+        subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
     }
 }
 
@@ -225,6 +267,7 @@ impl Lifecycle for MqttDriver {
             .lock()
             .map_err(|_| "failed to lock MQTT session".to_string())?;
         *guard = None;
+        self.broadcast_listener_status(self.listener_status()?)?;
         Ok(())
     }
 
@@ -353,8 +396,10 @@ impl EventSource for MqttDriver {
         let session = Arc::clone(&self.session);
         let running = Arc::clone(&self.listener_running);
         let listener_error = Arc::clone(&self.listener_error);
+        let status_subscribers = Arc::clone(&self.listener_status_subscribers);
         let device_id = self.dvc.id.clone();
         self.clear_listener_error()?;
+        self.broadcast_listener_status(MqttListenerStatus::Running)?;
         let handle = std::thread::spawn(move || {
             let mut sink = sink;
             while running.load(Ordering::SeqCst) {
@@ -366,6 +411,12 @@ impl EventSource for MqttDriver {
                                 *error_guard =
                                     Some("failed to lock MQTT session while listening".to_string());
                             }
+                            broadcast_listener_status_to_subscribers(
+                                &status_subscribers,
+                                MqttListenerStatus::Failed(
+                                    "failed to lock MQTT session while listening".to_string(),
+                                ),
+                            );
                             break;
                         }
                     };
@@ -376,6 +427,12 @@ impl EventSource for MqttDriver {
                                 *error_guard =
                                     Some("MQTT session missing while listener was running".to_string());
                             }
+                            broadcast_listener_status_to_subscribers(
+                                &status_subscribers,
+                                MqttListenerStatus::Failed(
+                                    "MQTT session missing while listener was running".to_string(),
+                                ),
+                            );
                             break;
                         }
                     };
@@ -396,6 +453,12 @@ impl EventSource for MqttDriver {
                                     *error_guard =
                                         Some("failed to forward MQTT event to sink".to_string());
                                 }
+                                broadcast_listener_status_to_subscribers(
+                                    &status_subscribers,
+                                    MqttListenerStatus::Failed(
+                                        "failed to forward MQTT event to sink".to_string(),
+                                    ),
+                                );
                                 running.store(false, Ordering::SeqCst);
                                 break;
                             }
@@ -403,14 +466,28 @@ impl EventSource for MqttDriver {
                     }
                     Err(error) => {
                         if let Ok(mut error_guard) = listener_error.lock() {
-                            *error_guard = Some(error);
+                            *error_guard = Some(error.clone());
                         }
+                        broadcast_listener_status_to_subscribers(
+                            &status_subscribers,
+                            MqttListenerStatus::Failed(error),
+                        );
                         running.store(false, Ordering::SeqCst);
                         break;
                     }
                 }
             }
             running.store(false, Ordering::SeqCst);
+            let final_status = match listener_error.lock() {
+                Ok(error_guard) => match error_guard.clone() {
+                    Some(error) => MqttListenerStatus::Failed(error),
+                    None => MqttListenerStatus::Stopped,
+                },
+                Err(_) => MqttListenerStatus::Failed(
+                    "failed to lock MQTT listener error after listener exit".to_string(),
+                ),
+            };
+            broadcast_listener_status_to_subscribers(&status_subscribers, final_status);
         });
 
         let mut handle_guard = self

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -33,6 +33,10 @@ mod runtime_stack {
     };
 }
 
+// compile error when no runtime stack feature is enabled
+#[cfg(not(any(feature = "tokio-runtime", feature = "async-std-runtime")))]
+compile_error!("ferredge-proto-mqtt requires a supported runtime stack feature to be enabled");
+
 use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
 
 type RuntimeSender<T> = <StackRuntime as AsyncRuntime>::Sender<T>;

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -13,9 +13,9 @@ extern crate alloc;
 
 #[cfg(feature = "std")]
 use std::sync::{
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
     mpsc,
-    Arc, Mutex,
 };
 
 #[cfg(feature = "std")]
@@ -29,16 +29,36 @@ use ferredge_core::prelude::*;
 mod convert;
 #[cfg(feature = "std")]
 mod runtime;
+mod types;
+#[cfg(all(feature = "tokio-runtime", feature = "async-std-runtime"))]
+compile_error!("ferredge-proto-mqtt supports only one std runtime stack feature at a time");
+#[cfg(feature = "tokio-runtime")]
+mod runtime_stack {
+    pub use ferredge_runtime_tokio::{
+        TokioNet as StackNet, TokioRuntime as StackRuntime, TokioSocket as StackSocket,
+        TokioTask as RuntimeTask,
+    };
+}
+#[cfg(feature = "async-std-runtime")]
+mod runtime_stack {
+    pub use ferredge_runtime_async_std::{
+        AsyncStdNet as StackNet, AsyncStdRuntime as StackRuntime, AsyncStdSocket as StackSocket,
+        AsyncStdTask as RuntimeTask,
+    };
+}
+
+#[cfg(feature = "std")]
+use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
+
 #[cfg(test)]
 mod tests;
-mod types;
 
 use types::{MqttPacketRequest, MqttResourceAttributes};
 
 #[cfg(feature = "std")]
 use runtime::{
-    build_connect_packet, handle_connection_events, mqtt_version_from_core,
-    normalize_broker_addr, read_from_session, send_packet_request, MqttClientSession,
+    MqttClientSession, build_connect_packet, handle_connection_events, mqtt_version_from_core,
+    normalize_broker_addr, read_from_session, send_packet_request,
 };
 
 pub use types::{
@@ -55,6 +75,9 @@ pub enum MqttListenerStatus {
     /// Listener stopped after a runtime or sink failure.
     Failed(String),
 }
+
+#[cfg(feature = "std")]
+const MQTT_LISTENER_EVENT_BUFFER_CAPACITY: usize = 256;
 
 /// MQTT adapter backed by `mqtt_protocol_core` packet builders.
 ///
@@ -73,18 +96,26 @@ pub struct MqttDriver {
     listener_running: Arc<AtomicBool>,
     /// Background listener thread handle.
     #[cfg(feature = "std")]
-    listener_handle: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+    listener_handle: Arc<Mutex<Option<RuntimeTask<()>>>>,
     /// Last background listener failure, if any.
     #[cfg(feature = "std")]
     listener_error: Arc<Mutex<Option<String>>>,
     /// Subscribers interested in listener status transitions.
     #[cfg(feature = "std")]
     listener_status_subscribers: Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
+    /// Std compatibility runtime used for background tasks and bounded channels.
+    #[cfg(feature = "std")]
+    runtime: Arc<StackRuntime>,
+    /// Std compatibility network adapter used for outbound sockets.
+    #[cfg(feature = "std")]
+    net: StackNet,
 }
 
 impl core::fmt::Debug for MqttDriver {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MqttDriver").field("dvc", &self.dvc).finish()
+        f.debug_struct("MqttDriver")
+            .field("dvc", &self.dvc)
+            .finish()
     }
 }
 
@@ -103,6 +134,10 @@ impl MqttDriver {
             listener_error: Arc::new(Mutex::new(None)),
             #[cfg(feature = "std")]
             listener_status_subscribers: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(feature = "std")]
+            runtime: Arc::new(StackRuntime::default()),
+            #[cfg(feature = "std")]
+            net: StackNet::default(),
         }
     }
 
@@ -123,7 +158,12 @@ impl MqttDriver {
         let session = guard
             .as_mut()
             .ok_or_else(|| "MQTT session not initialized".to_string())?;
-        read_from_session(session, &self.dvc.id, Some(std::time::Duration::from_millis(50)))
+        read_from_session(
+            self.runtime.as_ref(),
+            session,
+            &self.dvc.id,
+            Some(std::time::Duration::from_millis(50)),
+        )
     }
 
     #[cfg(feature = "std")]
@@ -141,20 +181,22 @@ impl MqttDriver {
             _ => return Err("device endpoint is not MQTT".to_string()),
         };
 
-        let stream = std::net::TcpStream::connect(normalize_broker_addr(&config.broker))
-            .map_err(|e| format!("failed to connect to MQTT broker: {e}"))?;
+        let mut stream = self.runtime.block_on(
+            self.net
+                .connect(normalize_broker_addr(&config.broker).as_str()),
+        )
+            .map_err(|e| format!("failed to connect to MQTT broker: {e:?}"))?;
         stream
             .set_read_timeout(Some(std::time::Duration::from_millis(1000)))
-            .map_err(|e| format!("failed to set MQTT read timeout: {e}"))?;
+            .map_err(|e| format!("failed to set MQTT read timeout: {e:?}"))?;
         stream
             .set_write_timeout(Some(std::time::Duration::from_millis(1000)))
-            .map_err(|e| format!("failed to set MQTT write timeout: {e}"))?;
+            .map_err(|e| format!("failed to set MQTT write timeout: {e:?}"))?;
 
         let version = mqtt_version_from_core(config.preferred_protocol_version());
-        let mut connection =
-            mqtt_protocol_core::mqtt::Connection::<mqtt_protocol_core::mqtt::role::Client>::new(
-                version,
-            );
+        let mut connection = mqtt_protocol_core::mqtt::Connection::<
+            mqtt_protocol_core::mqtt::role::Client,
+        >::new(version);
         connection.set_auto_pub_response(true);
 
         let connect_packet = build_connect_packet(config)?;
@@ -165,8 +207,9 @@ impl MqttDriver {
             pending_reply_routes: std::collections::HashMap::new(),
         };
         let events = session.connection.checked_send(connect_packet);
-        handle_connection_events(&mut session, &self.dvc.id, events)?;
+        handle_connection_events(self.runtime.as_ref(), &mut session, &self.dvc.id, events)?;
         let _ = read_from_session(
+            self.runtime.as_ref(),
             &mut session,
             &self.dvc.id,
             Some(std::time::Duration::from_millis(1000)),
@@ -184,7 +227,8 @@ impl MqttDriver {
             .lock()
             .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
         if let Some(handle) = handle_guard.take() {
-            if handle.join().is_err() {
+            let mut handle = handle;
+            if self.runtime.block_on(handle.join()).is_err() {
                 let mut error_guard = self
                     .listener_error
                     .lock()
@@ -270,30 +314,30 @@ fn broadcast_listener_status_to_subscribers(
 impl Lifecycle for MqttDriver {
     type Error = String;
 
-    #[cfg(feature = "std")]
     async fn start(&self) -> Result<(), Self::Error> {
-        self.connect()
-    }
+        #[cfg(feature = "std")]
+        {
+            return self.connect();
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn start(&self) -> Result<(), Self::Error> {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
-    #[cfg(feature = "std")]
     async fn stop(&self) -> Result<(), Self::Error> {
-        self.stop_listener()?;
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        *guard = None;
-        self.broadcast_listener_status(self.listener_status()?)?;
-        Ok(())
-    }
+        #[cfg(feature = "std")]
+        {
+            self.stop_listener()?;
+            let mut guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            *guard = None;
+            self.broadcast_listener_status(self.listener_status()?)?;
+            return Ok(());
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn stop(&self) -> Result<(), Self::Error> {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }
@@ -303,32 +347,32 @@ impl PubSub for MqttDriver {
     type Subscription = MqttPacketRequest;
     type Error = String;
 
-    #[cfg(feature = "std")]
     async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
-        self.ensure_connected()?;
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        let session = guard
-            .as_mut()
-            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+        #[cfg(feature = "std")]
+        {
+            self.ensure_connected()?;
+            let mut guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            let session = guard
+                .as_mut()
+                .ok_or_else(|| "MQTT session not initialized".to_string())?;
 
-        send_packet_request(session, &self.dvc.id, request)?;
-        let _ = read_from_session(
-            session,
-            &self.dvc.id,
-            Some(std::time::Duration::from_millis(250)),
-        )?;
-        Ok(())
-    }
+            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, request)?;
+            let _ = read_from_session(
+                self.runtime.as_ref(),
+                session,
+                &self.dvc.id,
+                Some(std::time::Duration::from_millis(250)),
+            )?;
+            return Ok(());
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn publish(&self, _request: Self::PublishRequest) -> Result<(), Self::Error> {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
-    #[cfg(feature = "std")]
     async fn subscribe<S>(
         &self,
         subscription: Self::Subscription,
@@ -337,65 +381,61 @@ impl PubSub for MqttDriver {
     where
         S: EventSink<Event = RoutedEvent> + Send,
     {
-        self.ensure_connected()?;
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        let session = guard
-            .as_mut()
-            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+        #[cfg(feature = "std")]
+        {
+            self.ensure_connected()?;
+            let mut guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            let session = guard
+                .as_mut()
+                .ok_or_else(|| "MQTT session not initialized".to_string())?;
 
-        send_packet_request(session, &self.dvc.id, subscription)?;
-        let messages = read_from_session(
-            session,
-            &self.dvc.id,
-            Some(std::time::Duration::from_millis(250)),
-        )?;
-        let mut sink = sink;
-        for message in messages {
-            if let RoutedMessage::Event(event) = message {
-                sink.handle(event)
-                    .map_err(|_| "failed to forward MQTT event to sink".to_string())?;
+            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, subscription)?;
+            let messages = read_from_session(
+                self.runtime.as_ref(),
+                session,
+                &self.dvc.id,
+                Some(std::time::Duration::from_millis(250)),
+            )?;
+            let mut sink = sink;
+            for message in messages {
+                if let RoutedMessage::Event(event) = message {
+                    sink.handle(event)
+                        .map_err(|_| "failed to forward MQTT event to sink".to_string())?;
+                }
             }
+            return Ok(());
         }
-        Ok(())
-    }
 
-    #[cfg(not(feature = "std"))]
-    async fn subscribe<S>(
-        &self,
-        _subscription: Self::Subscription,
-        _sink: S,
-    ) -> Result<(), Self::Error>
-    where
-        S: EventSink<Event = RoutedEvent> + Send,
-    {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
-    #[cfg(feature = "std")]
     async fn unsubscribe(&self, subscription: Self::Subscription) -> Result<(), Self::Error> {
-        self.ensure_connected()?;
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        let session = guard
-            .as_mut()
-            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+        #[cfg(feature = "std")]
+        {
+            self.ensure_connected()?;
+            let mut guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            let session = guard
+                .as_mut()
+                .ok_or_else(|| "MQTT session not initialized".to_string())?;
 
-        send_packet_request(session, &self.dvc.id, subscription)?;
-        let _ = read_from_session(
-            session,
-            &self.dvc.id,
-            Some(std::time::Duration::from_millis(250)),
-        )?;
-        Ok(())
-    }
+            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, subscription)?;
+            let _ = read_from_session(
+                self.runtime.as_ref(),
+                session,
+                &self.dvc.id,
+                Some(std::time::Duration::from_millis(250)),
+            )?;
+            return Ok(());
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn unsubscribe(&self, _subscription: Self::Subscription) -> Result<(), Self::Error> {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }
@@ -404,136 +444,200 @@ impl EventSource for MqttDriver {
     type Event = RoutedEvent;
     type Error = String;
 
-    #[cfg(feature = "std")]
     async fn start_listening<S>(&self, sink: S) -> Result<(), Self::Error>
     where
         S: EventSink<Event = Self::Event> + Send + 'static,
     {
-        self.ensure_connected()?;
-        if self.listener_running.swap(true, Ordering::SeqCst) {
-            return Err("MQTT listener already running".to_string());
-        }
+        #[cfg(feature = "std")]
+        {
+            self.ensure_connected()?;
+            if self.listener_running.swap(true, Ordering::SeqCst) {
+                return Err("MQTT listener already running".to_string());
+            }
 
-        let session = Arc::clone(&self.session);
-        let running = Arc::clone(&self.listener_running);
-        let listener_error = Arc::clone(&self.listener_error);
-        let status_subscribers = Arc::clone(&self.listener_status_subscribers);
-        let device_id = self.dvc.id.clone();
-        self.clear_listener_error()?;
-        self.broadcast_listener_status(MqttListenerStatus::Running)?;
-        let handle = std::thread::spawn(move || {
-            let mut sink = sink;
-            while running.load(Ordering::SeqCst) {
-                let messages = {
-                    let mut guard = match session.lock() {
-                        Ok(guard) => guard,
-                        Err(_) => {
-                            if let Ok(mut error_guard) = listener_error.lock() {
-                                *error_guard =
-                                    Some("failed to lock MQTT session while listening".to_string());
+            let session = Arc::clone(&self.session);
+            let running = Arc::clone(&self.listener_running);
+            let listener_error = Arc::clone(&self.listener_error);
+            let status_subscribers = Arc::clone(&self.listener_status_subscribers);
+            let device_id = self.dvc.id.clone();
+            let runtime = self.runtime.clone();
+            self.clear_listener_error()?;
+            self.broadcast_listener_status(MqttListenerStatus::Running)?;
+            let handle = runtime.clone().spawn(async move {
+                let (event_tx, mut event_rx) =
+                    runtime.channel::<RoutedEvent>(MQTT_LISTENER_EVENT_BUFFER_CAPACITY);
+                let sink_running = Arc::clone(&running);
+                let sink_listener_error = Arc::clone(&listener_error);
+                let sink_status_subscribers = Arc::clone(&status_subscribers);
+                let sink_runtime = runtime.clone();
+                let mut sink_handle = sink_runtime.spawn(async move {
+                    let mut sink = sink;
+                    loop {
+                        match event_rx.recv().await {
+                            Ok(event) => {
+                                if sink.handle(event).is_err() {
+                                    if let Ok(mut error_guard) = sink_listener_error.lock() {
+                                        *error_guard =
+                                            Some("failed to forward MQTT event to sink".to_string());
+                                    }
+                                    broadcast_listener_status_to_subscribers(
+                                        &sink_status_subscribers,
+                                        MqttListenerStatus::Failed(
+                                            "failed to forward MQTT event to sink".to_string(),
+                                        ),
+                                    );
+                                    sink_running.store(false, Ordering::SeqCst);
+                                    break;
+                                }
                             }
-                            broadcast_listener_status_to_subscribers(
-                                &status_subscribers,
-                                MqttListenerStatus::Failed(
-                                    "failed to lock MQTT session while listening".to_string(),
-                                ),
-                            );
-                            break;
+                            Err(ChannelError::Closed | ChannelError::RuntimeUnavailable) => break,
+                            Err(ChannelError::Full) => {}
                         }
-                    };
-                    let session = match guard.as_mut() {
-                        Some(session) => session,
-                        None => {
-                            if let Ok(mut error_guard) = listener_error.lock() {
-                                *error_guard =
-                                    Some("MQTT session missing while listener was running".to_string());
-                            }
-                            broadcast_listener_status_to_subscribers(
-                                &status_subscribers,
-                                MqttListenerStatus::Failed(
-                                    "MQTT session missing while listener was running".to_string(),
-                                ),
-                            );
-                            break;
-                        }
-                    };
-                    read_from_session(
-                        session,
-                        &device_id,
-                        Some(std::time::Duration::from_millis(250)),
-                    )
-                };
+                    }
+                });
 
-                match messages {
-                    Ok(messages) => {
-                        for message in messages {
-                            if let RoutedMessage::Event(event) = message
-                                && sink.handle(event).is_err()
-                            {
+                while running.load(Ordering::SeqCst) {
+                    let messages = {
+                        let mut guard = match session.lock() {
+                            Ok(guard) => guard,
+                            Err(_) => {
                                 if let Ok(mut error_guard) = listener_error.lock() {
-                                    *error_guard =
-                                        Some("failed to forward MQTT event to sink".to_string());
+                                    *error_guard = Some(
+                                        "failed to lock MQTT session while listening".to_string(),
+                                    );
                                 }
                                 broadcast_listener_status_to_subscribers(
                                     &status_subscribers,
                                     MqttListenerStatus::Failed(
-                                        "failed to forward MQTT event to sink".to_string(),
+                                        "failed to lock MQTT session while listening".to_string(),
                                     ),
                                 );
-                                running.store(false, Ordering::SeqCst);
                                 break;
                             }
+                        };
+                        let session = match guard.as_mut() {
+                            Some(session) => session,
+                            None => {
+                                if let Ok(mut error_guard) = listener_error.lock() {
+                                    *error_guard = Some(
+                                        "MQTT session missing while listener was running".to_string(),
+                                    );
+                                }
+                                broadcast_listener_status_to_subscribers(
+                                    &status_subscribers,
+                                    MqttListenerStatus::Failed(
+                                        "MQTT session missing while listener was running"
+                                            .to_string(),
+                                    ),
+                                );
+                                break;
+                            }
+                        };
+                        read_from_session(
+                            runtime.as_ref(),
+                            session,
+                            &device_id,
+                            Some(std::time::Duration::from_millis(250)),
+                        )
+                    };
+
+                    match messages {
+                        Ok(messages) => {
+                            for message in messages {
+                                if let RoutedMessage::Event(event) = message {
+                                    match event_tx.try_send(event) {
+                                        Ok(()) => {}
+                                        Err(ChannelError::Full) => {
+                                            if let Ok(mut error_guard) = listener_error.lock() {
+                                                *error_guard = Some(
+                                                    "MQTT listener event backlog exceeded"
+                                                        .to_string(),
+                                                );
+                                            }
+                                            broadcast_listener_status_to_subscribers(
+                                                &status_subscribers,
+                                                MqttListenerStatus::Failed(
+                                                    "MQTT listener event backlog exceeded"
+                                                        .to_string(),
+                                                ),
+                                            );
+                                            running.store(false, Ordering::SeqCst);
+                                            break;
+                                        }
+                                        Err(
+                                            ChannelError::Closed
+                                                | ChannelError::RuntimeUnavailable,
+                                        ) => {
+                                            if let Ok(mut error_guard) = listener_error.lock() {
+                                                *error_guard = Some(
+                                                    "MQTT listener sink worker disconnected"
+                                                        .to_string(),
+                                                );
+                                            }
+                                            broadcast_listener_status_to_subscribers(
+                                                &status_subscribers,
+                                                MqttListenerStatus::Failed(
+                                                    "MQTT listener sink worker disconnected"
+                                                        .to_string(),
+                                                ),
+                                            );
+                                            running.store(false, Ordering::SeqCst);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
                         }
-                    }
-                    Err(error) => {
-                        if let Ok(mut error_guard) = listener_error.lock() {
-                            *error_guard = Some(error.clone());
+                        Err(error) => {
+                            if let Ok(mut error_guard) = listener_error.lock() {
+                                *error_guard = Some(error.clone());
+                            }
+                            broadcast_listener_status_to_subscribers(
+                                &status_subscribers,
+                                MqttListenerStatus::Failed(error),
+                            );
+                            running.store(false, Ordering::SeqCst);
+                            break;
                         }
-                        broadcast_listener_status_to_subscribers(
-                            &status_subscribers,
-                            MqttListenerStatus::Failed(error),
-                        );
-                        running.store(false, Ordering::SeqCst);
-                        break;
                     }
                 }
-            }
-            running.store(false, Ordering::SeqCst);
-            let final_status = match listener_error.lock() {
-                Ok(error_guard) => match error_guard.clone() {
-                    Some(error) => MqttListenerStatus::Failed(error),
-                    None => MqttListenerStatus::Stopped,
-                },
-                Err(_) => MqttListenerStatus::Failed(
-                    "failed to lock MQTT listener error after listener exit".to_string(),
-                ),
-            };
-            broadcast_listener_status_to_subscribers(&status_subscribers, final_status);
-        });
+                running.store(false, Ordering::SeqCst);
+                drop(event_tx);
+                let _ = runtime.block_on(sink_handle.join());
+                let final_status = match listener_error.lock() {
+                    Ok(error_guard) => match error_guard.clone() {
+                        Some(error) => MqttListenerStatus::Failed(error),
+                        None => MqttListenerStatus::Stopped,
+                    },
+                    Err(_) => MqttListenerStatus::Failed(
+                        "failed to lock MQTT listener error after listener exit".to_string(),
+                    ),
+                };
+                broadcast_listener_status_to_subscribers(&status_subscribers, final_status);
+            });
 
-        let mut handle_guard = self
-            .listener_handle
-            .lock()
-            .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
-        *handle_guard = Some(handle);
-        Ok(())
+            let mut handle_guard = self
+                .listener_handle
+                .lock()
+                .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
+            *handle_guard = Some(handle);
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            let _ = sink;
+            Err("MQTT runtime requires the \"std\" feature".to_string())
+        }
     }
 
-    #[cfg(feature = "std")]
     async fn stop_listening(&self) -> Result<(), Self::Error> {
-        self.stop_listener()
-    }
+        #[cfg(feature = "std")]
+        {
+            return self.stop_listener();
+        }
 
-    #[cfg(not(feature = "std"))]
-    async fn start_listening<S>(&self, _sink: S) -> Result<(), Self::Error>
-    where
-        S: EventSink<Event = Self::Event> + Send + 'static,
-    {
-        Err("MQTT runtime requires the \"std\" feature".to_string())
-    }
-
-    #[cfg(not(feature = "std"))]
-    async fn stop_listening(&self) -> Result<(), Self::Error> {
+        #[cfg(not(feature = "std"))]
         Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -50,6 +50,11 @@ mod runtime_stack {
 #[cfg(feature = "std")]
 use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
 
+#[cfg(feature = "std")]
+type RuntimeSender<T> = <StackRuntime as AsyncRuntime>::Sender<T>;
+#[cfg(feature = "std")]
+type RuntimeReceiver<T> = <StackRuntime as AsyncRuntime>::Receiver<T>;
+
 #[cfg(all(test, feature = "mosquitto-tests"))]
 mod mosquitto_tests;
 #[cfg(test)]
@@ -66,6 +71,19 @@ use runtime::{
 pub use types::{
     MqttCommandConversionError, MqttPublishRequest, MqttSubscriptionRequest, MqttWirePacket,
 };
+
+#[cfg(feature = "std")]
+const MQTT_CONNECT_IO_TIMEOUT_MS: u64 = 1_000;
+#[cfg(feature = "std")]
+const MQTT_ACK_READ_TIMEOUT_MS: u64 = 250;
+#[cfg(feature = "std")]
+const MQTT_LISTENER_IDLE_POLL_MS: u64 = 250;
+#[cfg(feature = "std")]
+const MQTT_SESSION_WAIT_POLL_MS: u64 = 10;
+#[cfg(feature = "std")]
+const MQTT_LISTENER_COMMAND_TIMEOUT_MS: u64 = 750;
+#[cfg(feature = "std")]
+const MQTT_LISTENER_COMMAND_CHANNEL_CAPACITY: usize = 64;
 
 /// Current state of the MQTT background listener runtime.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -102,6 +120,9 @@ pub struct MqttDriver {
     /// Subscribers interested in listener status transitions.
     #[cfg(feature = "std")]
     listener_status_subscribers: Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
+    /// Command path into the active listener-owned session.
+    #[cfg(feature = "std")]
+    listener_command_sender: Arc<Mutex<Option<RuntimeSender<SessionCommand>>>>,
     /// Selected runtime used for background tasks.
     #[cfg(feature = "std")]
     runtime: Arc<StackRuntime>,
@@ -140,6 +161,8 @@ impl MqttDriver {
             #[cfg(feature = "std")]
             listener_status_subscribers: Arc::new(Mutex::new(Vec::new())),
             #[cfg(feature = "std")]
+            listener_command_sender: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "std")]
             runtime: Arc::new(StackRuntime::default()),
             #[cfg(feature = "std")]
             net: StackNet::default(),
@@ -173,10 +196,14 @@ impl MqttDriver {
             .await
             .map_err(|e| format!("failed to connect to MQTT broker: {e:?}"))?;
         stream
-            .set_read_timeout(Some(std::time::Duration::from_millis(1000)))
+            .set_read_timeout(Some(std::time::Duration::from_millis(
+                MQTT_CONNECT_IO_TIMEOUT_MS,
+            )))
             .map_err(|e| format!("failed to set MQTT read timeout: {e:?}"))?;
         stream
-            .set_write_timeout(Some(std::time::Duration::from_millis(1000)))
+            .set_write_timeout(Some(std::time::Duration::from_millis(
+                MQTT_CONNECT_IO_TIMEOUT_MS,
+            )))
             .map_err(|e| format!("failed to set MQTT write timeout: {e:?}"))?;
 
         let version = mqtt_version_from_core(config.preferred_protocol_version());
@@ -201,7 +228,7 @@ impl MqttDriver {
         let _ = read_from_session_async(
             &mut session,
             &self.dvc.id,
-            Some(std::time::Duration::from_millis(1000)),
+            Some(std::time::Duration::from_millis(MQTT_CONNECT_IO_TIMEOUT_MS)),
         )
         .await?;
 
@@ -286,10 +313,13 @@ impl MqttDriver {
     }
 
     #[cfg(feature = "std")]
-    async fn replay_recovery_state_async(&self) -> Result<(), String> {
+    async fn replay_recovery_state_on_session_async(
+        &self,
+        session: &mut MqttClientSession,
+    ) -> Result<Vec<RoutedEvent>, String> {
         let reconnect = self.reconnect_config()?;
-        let mut session = self.take_session_wait_async().await?;
         let result = async {
+            let mut recovered_events = Vec::new();
             if reconnect.replay_subscriptions {
                 let desired = self
                     .desired_subscriptions
@@ -299,13 +329,17 @@ impl MqttDriver {
                     .cloned()
                     .collect::<Vec<_>>();
                 for request in desired {
-                    send_packet_request_async(&mut session, &self.dvc.id, request).await?;
-                    let _ = read_from_session_async(
-                        &mut session,
+                    send_packet_request_async(session, &self.dvc.id, request).await?;
+                    let messages = read_from_session_async(
+                        session,
                         &self.dvc.id,
-                        Some(std::time::Duration::from_millis(250)),
+                        Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                     )
                     .await?;
+                    recovered_events.extend(messages.into_iter().filter_map(|message| match message {
+                        RoutedMessage::Event(event) => Some(event),
+                        _ => None,
+                    }));
                 }
             }
 
@@ -317,29 +351,35 @@ impl MqttDriver {
                 queue.drain(..).collect::<Vec<_>>()
             };
             for request in queued {
-                send_packet_request_async(&mut session, &self.dvc.id, request).await?;
-                let _ = read_from_session_async(
-                    &mut session,
+                send_packet_request_async(session, &self.dvc.id, request).await?;
+                let messages = read_from_session_async(
+                    session,
                     &self.dvc.id,
-                    Some(std::time::Duration::from_millis(250)),
+                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
+                recovered_events.extend(messages.into_iter().filter_map(|message| match message {
+                    RoutedMessage::Event(event) => Some(event),
+                    _ => None,
+                }));
             }
-            Ok::<(), String>(())
+            Ok::<Vec<RoutedEvent>, String>(recovered_events)
         }
         .await;
 
-        if result.is_ok() {
-            self.restore_session(session)?;
-        } else {
-            self.clear_session()?;
-        }
         result
     }
 
     #[cfg(feature = "std")]
     fn stop_listener(&self) -> Result<(), String> {
         self.listener_running.store(false, Ordering::SeqCst);
+        {
+            let mut sender_guard = self
+                .listener_command_sender
+                .lock()
+                .map_err(|_| "failed to lock MQTT listener command sender".to_string())?;
+            *sender_guard = None;
+        }
         let mut handle_guard = self
             .listener_handle
             .lock()
@@ -441,6 +481,48 @@ impl MqttDriver {
     }
 
     #[cfg(feature = "std")]
+    async fn send_listener_command(
+        &self,
+        command: SessionCommand,
+    ) -> Result<SessionCommandResult, String> {
+        let sender = self
+            .listener_command_sender
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener command sender".to_string())?
+            .clone()
+            .ok_or_else(|| "MQTT listener command path is not initialized".to_string())?;
+
+        let (response_tx, mut response_rx) = self.runtime.channel(1);
+        let command = command.with_response(response_tx);
+        sender
+            .send(command)
+            .await
+            .map_err(|_| "failed to send MQTT command to listener".to_string())?;
+
+        let deadline = std::time::Instant::now()
+            + std::time::Duration::from_millis(MQTT_LISTENER_COMMAND_TIMEOUT_MS);
+        loop {
+            match response_rx.try_recv() {
+                Ok(result) => return result,
+                Err(ChannelError::Empty) => {
+                    if std::time::Instant::now() >= deadline {
+                        return Err("MQTT listener command timed out".to_string());
+                    }
+                    self.runtime
+                        .sleep(core::time::Duration::from_millis(MQTT_SESSION_WAIT_POLL_MS))
+                        .await;
+                }
+                Err(ChannelError::Closed) => {
+                    return Err("MQTT listener command response channel closed".to_string());
+                }
+                Err(ChannelError::Full | ChannelError::RuntimeUnavailable) => {
+                    return Err("MQTT listener command response unavailable".to_string());
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
     async fn take_session_wait_async(&self) -> Result<MqttClientSession, String> {
         loop {
             {
@@ -457,7 +539,7 @@ impl MqttDriver {
             }
 
             self.runtime
-                .sleep(core::time::Duration::from_millis(10))
+                .sleep(core::time::Duration::from_millis(MQTT_SESSION_WAIT_POLL_MS))
                 .await;
         }
     }
@@ -484,6 +566,35 @@ impl MqttDriver {
 }
 
 #[cfg(feature = "std")]
+#[derive(Debug)]
+enum SessionCommandKind {
+    Publish(MqttPacketRequest),
+    Subscribe(MqttPacketRequest),
+    Unsubscribe(MqttPacketRequest),
+}
+
+#[cfg(feature = "std")]
+struct SessionCommand {
+    kind: SessionCommandKind,
+    response: Option<RuntimeSender<Result<SessionCommandResult, String>>>,
+}
+
+#[cfg(feature = "std")]
+impl SessionCommand {
+    fn with_response(mut self, response: RuntimeSender<Result<SessionCommandResult, String>>) -> Self {
+        self.response = Some(response);
+        self
+    }
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+enum SessionCommandResult {
+    Done,
+    Events(Vec<RoutedEvent>),
+}
+
+#[cfg(feature = "std")]
 fn broadcast_listener_status_to_subscribers(
     subscribers: &Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
     status: MqttListenerStatus,
@@ -491,6 +602,62 @@ fn broadcast_listener_status_to_subscribers(
     if let Ok(mut subscribers) = subscribers.lock() {
         subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
     }
+}
+
+#[cfg(feature = "std")]
+async fn process_session_command(
+    session: &mut MqttClientSession,
+    device_id: &str,
+    command: SessionCommand,
+) -> Result<(), String> {
+    let response = match command.kind {
+        SessionCommandKind::Publish(request) => async {
+            send_packet_request_async(session, device_id, request).await?;
+            let _ = read_from_session_async(
+                session,
+                device_id,
+                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+            )
+            .await?;
+            Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+        }
+        .await,
+        SessionCommandKind::Subscribe(request) => async {
+            send_packet_request_async(session, device_id, request).await?;
+            let messages = read_from_session_async(
+                session,
+                device_id,
+                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+            )
+            .await?;
+            Ok::<SessionCommandResult, String>(SessionCommandResult::Events(
+                messages
+                    .into_iter()
+                    .filter_map(|message| match message {
+                        RoutedMessage::Event(event) => Some(event),
+                        _ => None,
+                    })
+                    .collect(),
+            ))
+        }
+        .await,
+        SessionCommandKind::Unsubscribe(request) => async {
+            send_packet_request_async(session, device_id, request).await?;
+            let _ = read_from_session_async(
+                session,
+                device_id,
+                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+            )
+            .await?;
+            Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+        }
+        .await,
+    };
+
+    if let Some(response_tx) = command.response {
+        let _ = response_tx.send(response.clone()).await;
+    }
+    response.map(|_| ())
 }
 
 impl Lifecycle for MqttDriver {
@@ -537,12 +704,25 @@ impl PubSub for MqttDriver {
     async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            if let Err(error) = self.ensure_connected_async().await {
-                if self.listener_running.load(Ordering::SeqCst)
-                    && self.enqueue_recovery_request(request.clone()).is_ok()
+            if self.listener_running.load(Ordering::SeqCst) {
+                match self
+                    .send_listener_command(SessionCommand {
+                        kind: SessionCommandKind::Publish(request.clone()),
+                        response: None,
+                    })
+                    .await
                 {
-                    return Ok(());
+                    Ok(SessionCommandResult::Done) => return Ok(()),
+                    Ok(SessionCommandResult::Events(_)) => return Ok(()),
+                    Err(error) => {
+                        if self.enqueue_recovery_request(request).is_ok() {
+                            return Ok(());
+                        }
+                        return Err(error);
+                    }
                 }
+            }
+            if let Err(error) = self.ensure_connected_async().await {
                 return Err(error);
             }
             let mut session = self.take_session_wait_async().await?;
@@ -551,7 +731,7 @@ impl PubSub for MqttDriver {
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
-                    Some(std::time::Duration::from_millis(250)),
+                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
                 Ok::<(), String>(())
@@ -585,12 +765,32 @@ impl PubSub for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.track_subscription_intent(&subscription)?;
-            if let Err(error) = self.ensure_connected_async().await {
-                if self.listener_running.load(Ordering::SeqCst)
-                    && self.enqueue_recovery_request(subscription.clone()).is_ok()
+            if self.listener_running.load(Ordering::SeqCst) {
+                match self
+                    .send_listener_command(SessionCommand {
+                        kind: SessionCommandKind::Subscribe(subscription.clone()),
+                        response: None,
+                    })
+                    .await
                 {
-                    return Ok(());
+                    Ok(SessionCommandResult::Done) => return Ok(()),
+                    Ok(SessionCommandResult::Events(events)) => {
+                        let mut sink = sink;
+                        for event in events {
+                            sink.handle(event)
+                                .map_err(|_| "failed to forward MQTT event to sink".to_string())?;
+                        }
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        if self.enqueue_recovery_request(subscription).is_ok() {
+                            return Ok(());
+                        }
+                        return Err(error);
+                    }
                 }
+            }
+            if let Err(error) = self.ensure_connected_async().await {
                 return Err(error);
             }
             let mut session = self.take_session_wait_async().await?;
@@ -599,7 +799,7 @@ impl PubSub for MqttDriver {
                 read_from_session_async(
                     &mut session,
                     &self.dvc.id,
-                    Some(std::time::Duration::from_millis(250)),
+                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await
             }
@@ -632,12 +832,26 @@ impl PubSub for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.track_subscription_intent(&subscription)?;
-            if let Err(error) = self.ensure_connected_async().await {
-                if self.listener_running.load(Ordering::SeqCst)
-                    && self.enqueue_recovery_request(subscription.clone()).is_ok()
+            if self.listener_running.load(Ordering::SeqCst) {
+                match self
+                    .send_listener_command(SessionCommand {
+                        kind: SessionCommandKind::Unsubscribe(subscription.clone()),
+                        response: None,
+                    })
+                    .await
                 {
-                    return Ok(());
+                    Ok(SessionCommandResult::Done) | Ok(SessionCommandResult::Events(_)) => {
+                        return Ok(());
+                    }
+                    Err(error) => {
+                        if self.enqueue_recovery_request(subscription).is_ok() {
+                            return Ok(());
+                        }
+                        return Err(error);
+                    }
                 }
+            }
+            if let Err(error) = self.ensure_connected_async().await {
                 return Err(error);
             }
             let mut session = self.take_session_wait_async().await?;
@@ -646,7 +860,7 @@ impl PubSub for MqttDriver {
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
-                    Some(std::time::Duration::from_millis(250)),
+                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
                 Ok::<(), String>(())
@@ -689,15 +903,26 @@ impl EventSource for MqttDriver {
             let running = Arc::clone(&self.listener_running);
             let listener_error = Arc::clone(&self.listener_error);
             let status_subscribers = Arc::clone(&self.listener_status_subscribers);
+            let listener_command_sender = Arc::clone(&self.listener_command_sender);
             let device_id = self.dvc.id.clone();
             let driver = self.clone();
             let runtime = self.runtime.clone();
             let reconnect = self.reconnect_config()?;
+            let (command_tx, command_rx): (RuntimeSender<SessionCommand>, RuntimeReceiver<SessionCommand>) =
+                runtime.channel(MQTT_LISTENER_COMMAND_CHANNEL_CAPACITY);
             self.clear_listener_error()?;
             self.broadcast_listener_status(MqttListenerStatus::Running)?;
+            {
+                let mut sender_guard = self
+                    .listener_command_sender
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT listener command sender".to_string())?;
+                *sender_guard = Some(command_tx);
+            }
             let handle = runtime.clone().spawn(async move {
                 let mut sink = sink;
                 let mut reconnect_attempt = 0u32;
+                let mut command_rx = command_rx;
 
                 'listen: while running.load(Ordering::SeqCst) {
                     let mut session_value = match {
@@ -722,14 +947,135 @@ impl EventSource for MqttDriver {
                     } {
                         Some(session) => session,
                         None => {
-                            runtime.sleep(core::time::Duration::from_millis(10)).await;
+                            runtime
+                                .sleep(core::time::Duration::from_millis(MQTT_SESSION_WAIT_POLL_MS))
+                                .await;
                             continue;
                         }
                     };
+
+                    loop {
+                        match command_rx.try_recv() {
+                            Ok(command) => {
+                                if let Err(error) =
+                                    process_session_command(&mut session_value, &device_id, command)
+                                        .await
+                                {
+                                    if let Ok(mut guard) = session.lock() {
+                                        *guard = None;
+                                    }
+                                    let mut error = error;
+                                    while running.load(Ordering::SeqCst) {
+                                        reconnect_attempt = reconnect_attempt.saturating_add(1);
+                                        if !reconnect.allows_attempt(reconnect_attempt) {
+                                            break;
+                                        }
+
+                                        runtime
+                                            .sleep(core::time::Duration::from_millis(
+                                                reconnect.delay_ms_for_attempt(reconnect_attempt),
+                                            ))
+                                            .await;
+
+                                        if !running.load(Ordering::SeqCst) {
+                                            break;
+                                        }
+
+                                        match driver.ensure_connected_async().await {
+                                            Ok(()) => {
+                                                let maybe_reconnected_session = {
+                                                    let mut guard = match session.lock() {
+                                                        Ok(guard) => guard,
+                                                        Err(_) => {
+                                                            error = "failed to lock MQTT session after reconnect".to_string();
+                                                            continue;
+                                                        }
+                                                    };
+                                                    guard.take()
+                                                };
+
+                                                let Some(mut reconnected_session) = maybe_reconnected_session else {
+                                                    error = "MQTT session missing after reconnect".to_string();
+                                                    continue;
+                                                };
+
+                                                let recovered_events = match driver
+                                                    .replay_recovery_state_on_session_async(
+                                                        &mut reconnected_session,
+                                                    )
+                                                    .await
+                                                {
+                                                    Ok(recovered_events) => recovered_events,
+                                                    Err(recovery_error) => {
+                                                        if let Ok(mut guard) = session.lock() {
+                                                            *guard = None;
+                                                        }
+                                                        error = recovery_error;
+                                                        continue;
+                                                    }
+                                                };
+
+                                                if let Ok(mut guard) = session.lock() {
+                                                    *guard = Some(reconnected_session);
+                                                }
+                                                for event in recovered_events {
+                                                    if sink.handle(event).is_err() {
+                                                        if let Ok(mut error_guard) =
+                                                            listener_error.lock()
+                                                        {
+                                                            *error_guard = Some(
+                                                                "failed to forward MQTT event to sink"
+                                                                    .to_string(),
+                                                            );
+                                                        }
+                                                        broadcast_listener_status_to_subscribers(
+                                                            &status_subscribers,
+                                                            MqttListenerStatus::Failed(
+                                                                "failed to forward MQTT event to sink"
+                                                                    .to_string(),
+                                                            ),
+                                                        );
+                                                        running.store(false, Ordering::SeqCst);
+                                                        break 'listen;
+                                                    }
+                                                }
+                                                reconnect_attempt = 0;
+                                                if let Ok(mut error_guard) = listener_error.lock() {
+                                                    *error_guard = None;
+                                                }
+                                                continue 'listen;
+                                            }
+                                            Err(connect_error) => {
+                                                error = connect_error;
+                                            }
+                                        }
+                                    }
+                                    if !running.load(Ordering::SeqCst) {
+                                        break 'listen;
+                                    }
+                                    if let Ok(mut error_guard) = listener_error.lock() {
+                                        *error_guard = Some(error.clone());
+                                    }
+                                    broadcast_listener_status_to_subscribers(
+                                        &status_subscribers,
+                                        MqttListenerStatus::Failed(error),
+                                    );
+                                    running.store(false, Ordering::SeqCst);
+                                    break 'listen;
+                                }
+                            }
+                            Err(ChannelError::Empty) => break,
+                            Err(ChannelError::Closed) => break,
+                            Err(ChannelError::Full | ChannelError::RuntimeUnavailable) => {
+                                break;
+                            }
+                        }
+                    }
+
                     let messages = read_from_session_async(
                         &mut session_value,
                         &device_id,
-                        Some(std::time::Duration::from_millis(250)),
+                        Some(std::time::Duration::from_millis(MQTT_LISTENER_IDLE_POLL_MS)),
                     )
                     .await;
 
@@ -781,11 +1127,40 @@ impl EventSource for MqttDriver {
 
                                 match driver.ensure_connected_async().await {
                                     Ok(()) => {
-                                        if let Err(recovery_error) =
-                                            driver.replay_recovery_state_async().await
+                                        let maybe_reconnected_session = {
+                                            let mut guard = match session.lock() {
+                                                Ok(guard) => guard,
+                                                Err(_) => {
+                                                    error =
+                                                        "failed to lock MQTT session after reconnect"
+                                                            .to_string();
+                                                    continue;
+                                                }
+                                            };
+                                            guard.take()
+                                        };
+
+                                        let Some(mut reconnected_session) = maybe_reconnected_session else {
+                                            error =
+                                                "MQTT session missing after reconnect".to_string();
+                                            continue;
+                                        };
+
+                                        if let Err(recovery_error) = driver
+                                            .replay_recovery_state_on_session_async(
+                                                &mut reconnected_session,
+                                            )
+                                            .await
                                         {
+                                            if let Ok(mut guard) = session.lock() {
+                                                *guard = None;
+                                            }
                                             error = recovery_error;
                                             continue;
+                                        }
+
+                                        if let Ok(mut guard) = session.lock() {
+                                            *guard = Some(reconnected_session);
                                         }
                                         reconnect_attempt = 0;
                                         if let Ok(mut error_guard) = listener_error.lock() {
@@ -815,6 +1190,9 @@ impl EventSource for MqttDriver {
                             break;
                         }
                     }
+                }
+                if let Ok(mut sender_guard) = listener_command_sender.lock() {
+                    *sender_guard = None;
                 }
                 running.store(false, Ordering::SeqCst);
                 let final_status = match listener_error.lock() {

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -1,22 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 //! MQTT protocol adapter for ferredge.
-//!
-//! With the default `std` feature, this crate provides a live TCP-backed MQTT client runtime,
-//! publish/subscribe operations, and background event listening.
-//!
-//! Without `std`, this crate still supports routed-command conversion into MQTT-native packet
-//! types through `TryFrom`, but transport runtime methods return explicit
-//! `requires the "std" feature` errors.
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
-
-#[cfg(feature = "std")]
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
-    mpsc,
-};
 
 #[cfg(feature = "std")]
 use std::string::{String, ToString};
@@ -47,13 +33,13 @@ mod runtime_stack {
     };
 }
 
-#[cfg(feature = "std")]
 use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
 
-#[cfg(feature = "std")]
 type RuntimeSender<T> = <StackRuntime as AsyncRuntime>::Sender<T>;
-#[cfg(feature = "std")]
+
 type RuntimeReceiver<T> = <StackRuntime as AsyncRuntime>::Receiver<T>;
+
+type RuntimeMutex<T> = <StackRuntime as AsyncRuntime>::Mutex<T>;
 
 #[cfg(all(test, feature = "mosquitto-tests"))]
 mod mosquitto_tests;
@@ -62,7 +48,6 @@ mod tests;
 
 use types::{MqttPacketRequest, MqttResourceAttributes};
 
-#[cfg(feature = "std")]
 use runtime::{
     MqttClientSession, build_connect_packet, disconnect_session, mqtt_version_from_core,
     normalize_broker_addr, read_from_session_async, send_packet_request_async,
@@ -72,17 +57,11 @@ pub use types::{
     MqttCommandConversionError, MqttPublishRequest, MqttSubscriptionRequest, MqttWirePacket,
 };
 
-#[cfg(feature = "std")]
 const MQTT_CONNECT_IO_TIMEOUT_MS: u64 = 1_000;
-#[cfg(feature = "std")]
 const MQTT_ACK_READ_TIMEOUT_MS: u64 = 250;
-#[cfg(feature = "std")]
 const MQTT_LISTENER_IDLE_POLL_MS: u64 = 250;
-#[cfg(feature = "std")]
 const MQTT_SESSION_WAIT_POLL_MS: u64 = 10;
-#[cfg(feature = "std")]
 const MQTT_LISTENER_COMMAND_TIMEOUT_MS: u64 = 750;
-#[cfg(feature = "std")]
 const MQTT_LISTENER_COMMAND_CHANNEL_CAPACITY: usize = 64;
 
 /// Current state of the MQTT background listener runtime.
@@ -106,38 +85,27 @@ pub struct MqttDriver {
     /// Device metadata and broker configuration served by this driver.
     pub dvc: Device<MqttResourceAttributes>,
     /// Live MQTT client session for std-enabled runtime transport.
-    #[cfg(feature = "std")]
-    session: Arc<Mutex<Option<MqttClientSession>>>,
+    session: Shared<RuntimeMutex<Option<MqttClientSession>>>,
     /// Last negotiated CONNACK capabilities and identifiers observed from broker.
-    #[cfg(feature = "std")]
-    negotiated_connack: Arc<Mutex<Option<MqttConnackProperties>>>,
+    negotiated_connack: Shared<RuntimeMutex<Option<MqttConnackProperties>>>,
     /// Background listener run flag.
-    #[cfg(feature = "std")]
-    listener_running: Arc<AtomicBool>,
+    listener_running: Shared<AtomicFlag>,
     /// Background listener task handle.
-    #[cfg(feature = "std")]
-    listener_handle: Arc<Mutex<Option<RuntimeTask<()>>>>,
+    listener_handle: Shared<RuntimeMutex<Option<RuntimeTask<()>>>>,
     /// Last background listener failure, if any.
-    #[cfg(feature = "std")]
-    listener_error: Arc<Mutex<Option<String>>>,
+    listener_error: Shared<RuntimeMutex<Option<String>>>,
     /// Subscribers interested in listener status transitions.
-    #[cfg(feature = "std")]
-    listener_status_subscribers: Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
+    listener_status_subscribers: Shared<RuntimeMutex<Vec<RuntimeSender<MqttListenerStatus>>>>,
     /// Command path into the active listener-owned session.
-    #[cfg(feature = "std")]
-    listener_command_sender: Arc<Mutex<Option<RuntimeSender<SessionCommand>>>>,
+    listener_command_sender: Shared<RuntimeMutex<Option<RuntimeSender<SessionCommand>>>>,
     /// Selected runtime used for background tasks.
-    #[cfg(feature = "std")]
-    runtime: Arc<StackRuntime>,
+    runtime: Shared<StackRuntime>,
     /// Selected network adapter used for outbound sockets.
-    #[cfg(feature = "std")]
     net: StackNet,
     /// Desired subscription state to replay after reconnect.
-    #[cfg(feature = "std")]
-    desired_subscriptions: Arc<Mutex<Map<String, MqttPacketRequest>>>,
+    desired_subscriptions: Shared<RuntimeMutex<Map<String, MqttPacketRequest>>>,
     /// Queued outbound requests waiting for broker recovery.
-    #[cfg(feature = "std")]
-    recovery_queue: Arc<Mutex<VecDeque<MqttPacketRequest>>>,
+    recovery_queue: Shared<RuntimeMutex<VecDeque<MqttPacketRequest>>>,
 }
 
 impl core::fmt::Debug for MqttDriver {
@@ -151,39 +119,30 @@ impl core::fmt::Debug for MqttDriver {
 impl MqttDriver {
     /// Creates a new MQTT driver from device metadata.
     pub fn new(dvc: Device<MqttResourceAttributes>) -> Self {
+        let runtime = Shared::new(StackRuntime::default());
+
         Self {
             dvc,
-            #[cfg(feature = "std")]
-            session: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "std")]
-            negotiated_connack: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "std")]
-            listener_running: Arc::new(AtomicBool::new(false)),
-            #[cfg(feature = "std")]
-            listener_handle: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "std")]
-            listener_error: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "std")]
-            listener_status_subscribers: Arc::new(Mutex::new(Vec::new())),
-            #[cfg(feature = "std")]
-            listener_command_sender: Arc::new(Mutex::new(None)),
-            #[cfg(feature = "std")]
-            runtime: Arc::new(StackRuntime::default()),
-            #[cfg(feature = "std")]
+            session: Shared::new(runtime.mutex(None)),
+            negotiated_connack: Shared::new(runtime.mutex(None)),
+            listener_running: Shared::new(AtomicFlag::new(false)),
+            listener_handle: Shared::new(runtime.mutex(None)),
+            listener_error: Shared::new(runtime.mutex(None)),
+            listener_status_subscribers: Shared::new(runtime.mutex(Vec::new())),
+            listener_command_sender: Shared::new(runtime.mutex(None)),
+            runtime: runtime.clone(),
             net: StackNet::default(),
-            #[cfg(feature = "std")]
-            desired_subscriptions: Arc::new(Mutex::new(Map::new())),
-            #[cfg(feature = "std")]
-            recovery_queue: Arc::new(Mutex::new(VecDeque::new())),
+            desired_subscriptions: Shared::new(runtime.mutex(Map::new())),
+            recovery_queue: Shared::new(runtime.mutex(VecDeque::new())),
         }
     }
 
-    #[cfg(feature = "std")]
     async fn ensure_connected_async(&self) -> Result<(), String> {
         {
             let guard = self
                 .session
                 .lock()
+                .await
                 .map_err(|_| "failed to lock MQTT session".to_string())?;
             if guard.is_some() {
                 return Ok(());
@@ -201,12 +160,12 @@ impl MqttDriver {
             .await
             .map_err(|e| format!("failed to connect to MQTT broker: {e:?}"))?;
         stream
-            .set_read_timeout(Some(std::time::Duration::from_millis(
+            .set_read_timeout(Some(core::time::Duration::from_millis(
                 MQTT_CONNECT_IO_TIMEOUT_MS,
             )))
             .map_err(|e| format!("failed to set MQTT read timeout: {e:?}"))?;
         stream
-            .set_write_timeout(Some(std::time::Duration::from_millis(
+            .set_write_timeout(Some(core::time::Duration::from_millis(
                 MQTT_CONNECT_IO_TIMEOUT_MS,
             )))
             .map_err(|e| format!("failed to set MQTT write timeout: {e:?}"))?;
@@ -223,13 +182,14 @@ impl MqttDriver {
             connection,
             protocol_version: config.preferred_protocol_version(),
             keepalive_secs: config.keepalive_secs,
-            last_activity: std::time::Instant::now(),
+            last_activity: self.runtime.now(),
             awaiting_pingresp: false,
-            pending_command_ids: std::collections::HashMap::new(),
-            pending_reply_routes: std::collections::HashMap::new(),
+            pending_command_ids: Map::new(),
+            pending_reply_routes: Map::new(),
         };
         let events = session.connection.checked_send(connect_packet);
         runtime::handle_connection_events_async(
+            &self.runtime,
             &mut session,
             &self.dvc.id,
             Some(&self.negotiated_connack),
@@ -237,16 +197,20 @@ impl MqttDriver {
         )
         .await?;
         let _ = read_from_session_async(
+            &self.runtime,
             &mut session,
             &self.dvc.id,
             Some(&self.negotiated_connack),
-            Some(std::time::Duration::from_millis(MQTT_CONNECT_IO_TIMEOUT_MS)),
+            Some(core::time::Duration::from_millis(
+                MQTT_CONNECT_IO_TIMEOUT_MS,
+            )),
         )
         .await?;
 
         let mut guard = self
             .session
             .lock()
+            .await
             .map_err(|_| "failed to lock MQTT session".to_string())?;
         if guard.is_none() {
             *guard = Some(session);
@@ -255,15 +219,15 @@ impl MqttDriver {
     }
 
     /// Returns the most recent broker CONNACK negotiation snapshot, if available.
-    #[cfg(feature = "std")]
+
     pub fn negotiated_connack(&self) -> Result<Option<MqttConnackProperties>, String> {
-        self.negotiated_connack
-            .lock()
-            .map(|guard| (*guard).clone())
-            .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())
+        let guard = self
+            .runtime
+            .block_on(self.negotiated_connack.lock())
+            .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())?;
+        Ok((*guard).clone())
     }
 
-    #[cfg(feature = "std")]
     fn reconnect_config(&self) -> Result<BrokerReconnectConfig, String> {
         match &self.dvc.endpoint {
             DeviceEndpoint::Mqtt(config) => Ok(config.reconnect.clone()),
@@ -271,7 +235,6 @@ impl MqttDriver {
         }
     }
 
-    #[cfg(feature = "std")]
     fn request_topic_key(request: &MqttPacketRequest) -> Option<String> {
         match &request.packet {
             MqttWirePacket::V5Subscribe(packet) => packet
@@ -294,14 +257,13 @@ impl MqttDriver {
         }
     }
 
-    #[cfg(feature = "std")]
     fn track_subscription_intent(&self, request: &MqttPacketRequest) -> Result<(), String> {
         let Some(topic) = Self::request_topic_key(request) else {
             return Ok(());
         };
         let mut desired = self
-            .desired_subscriptions
-            .lock()
+            .runtime
+            .block_on(self.desired_subscriptions.lock())
             .map_err(|_| "failed to lock MQTT desired subscriptions".to_string())?;
         match request.packet {
             MqttWirePacket::V5Subscribe(_) | MqttWirePacket::V3Subscribe(_) => {
@@ -315,7 +277,6 @@ impl MqttDriver {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     fn enqueue_recovery_request(&self, request: MqttPacketRequest) -> Result<(), String> {
         let reconnect = self.reconnect_config()?;
         if !reconnect.queue_requests_while_disconnected {
@@ -323,8 +284,8 @@ impl MqttDriver {
         }
 
         let mut queue = self
-            .recovery_queue
-            .lock()
+            .runtime
+            .block_on(self.recovery_queue.lock())
             .map_err(|_| "failed to lock MQTT recovery queue".to_string())?;
         if queue.len() >= reconnect.max_queued_requests as usize {
             queue.pop_front();
@@ -333,7 +294,6 @@ impl MqttDriver {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     async fn replay_recovery_state_on_session_async(
         &self,
         session: &mut MqttClientSession,
@@ -345,23 +305,28 @@ impl MqttDriver {
                 let desired = self
                     .desired_subscriptions
                     .lock()
+                    .await
                     .map_err(|_| "failed to lock MQTT desired subscriptions".to_string())?
                     .values()
                     .cloned()
                     .collect::<Vec<_>>();
                 for request in desired {
-                    send_packet_request_async(session, &self.dvc.id, request).await?;
+                    send_packet_request_async(&self.runtime, session, &self.dvc.id, request)
+                        .await?;
                     let messages = read_from_session_async(
+                        &self.runtime,
                         session,
                         &self.dvc.id,
                         Some(&self.negotiated_connack),
-                        Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                        Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                     )
                     .await?;
-                    recovered_events.extend(messages.into_iter().filter_map(|message| match message {
-                        RoutedMessage::Event(event) => Some(event),
-                        _ => None,
-                    }));
+                    recovered_events.extend(messages.into_iter().filter_map(
+                        |message| match message {
+                            RoutedMessage::Event(event) => Some(event),
+                            _ => None,
+                        },
+                    ));
                 }
             }
 
@@ -369,16 +334,18 @@ impl MqttDriver {
                 let mut queue = self
                     .recovery_queue
                     .lock()
+                    .await
                     .map_err(|_| "failed to lock MQTT recovery queue".to_string())?;
                 queue.drain(..).collect::<Vec<_>>()
             };
             for request in queued {
-                send_packet_request_async(session, &self.dvc.id, request).await?;
+                send_packet_request_async(&self.runtime, session, &self.dvc.id, request).await?;
                 let messages = read_from_session_async(
+                    &self.runtime,
                     session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
-                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
                 recovered_events.extend(messages.into_iter().filter_map(|message| match message {
@@ -393,26 +360,25 @@ impl MqttDriver {
         result
     }
 
-    #[cfg(feature = "std")]
     fn stop_listener(&self) -> Result<(), String> {
-        self.listener_running.store(false, Ordering::SeqCst);
+        self.listener_running.store(false, AtomicOrdering::SeqCst);
         {
             let mut sender_guard = self
-                .listener_command_sender
-                .lock()
+                .runtime
+                .block_on(self.listener_command_sender.lock())
                 .map_err(|_| "failed to lock MQTT listener command sender".to_string())?;
             *sender_guard = None;
         }
         let mut handle_guard = self
-            .listener_handle
-            .lock()
+            .runtime
+            .block_on(self.listener_handle.lock())
             .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
         if let Some(handle) = handle_guard.take() {
             let mut handle = handle;
             if self.runtime.block_on(handle.join()).is_err() {
                 let mut error_guard = self
-                    .listener_error
-                    .lock()
+                    .runtime
+                    .block_on(self.listener_error.lock())
                     .map_err(|_| "failed to lock MQTT listener error".to_string())?;
                 if error_guard.is_none() {
                     *error_guard = Some("MQTT listener task panicked".to_string());
@@ -425,13 +391,12 @@ impl MqttDriver {
 
     /// Returns the last background listener error captured by the runtime, if any.
     pub fn last_listener_error(&self) -> Result<Option<String>, String> {
-        #[cfg(feature = "std")]
         {
-            return self
-                .listener_error
-                .lock()
-                .map(|error| error.clone())
-                .map_err(|_| "failed to lock MQTT listener error".to_string());
+            let error = self
+                .runtime
+                .block_on(self.listener_error.lock())
+                .map_err(|_| "failed to lock MQTT listener error".to_string())?;
+            return Ok(error.clone());
         }
 
         #[cfg(not(feature = "std"))]
@@ -442,11 +407,10 @@ impl MqttDriver {
 
     /// Clears any previously captured background listener error.
     pub fn clear_listener_error(&self) -> Result<(), String> {
-        #[cfg(feature = "std")]
         {
             let mut guard = self
-                .listener_error
-                .lock()
+                .runtime
+                .block_on(self.listener_error.lock())
                 .map_err(|_| "failed to lock MQTT listener error".to_string())?;
             *guard = None;
             self.broadcast_listener_status(MqttListenerStatus::Stopped)?;
@@ -461,9 +425,8 @@ impl MqttDriver {
 
     /// Returns high-level background listener status for this MQTT driver.
     pub fn listener_status(&self) -> Result<MqttListenerStatus, String> {
-        #[cfg(feature = "std")]
         {
-            if self.listener_running.load(Ordering::SeqCst) {
+            if self.listener_running.load(AtomicOrdering::SeqCst) {
                 return Ok(MqttListenerStatus::Running);
             }
 
@@ -480,30 +443,33 @@ impl MqttDriver {
     }
 
     /// Subscribes to background listener status changes for this MQTT driver.
-    #[cfg(feature = "std")]
-    pub fn subscribe_listener_status(&self) -> Result<mpsc::Receiver<MqttListenerStatus>, String> {
-        let (tx, rx) = mpsc::channel();
+
+    pub fn subscribe_listener_status(&self) -> Result<RuntimeReceiver<MqttListenerStatus>, String> {
+        let (tx, rx) = self.runtime.channel(8);
         let current = self.listener_status()?;
-        tx.send(current)
+        tx.try_send(current)
             .map_err(|_| "failed to seed MQTT listener status subscriber".to_string())?;
-        self.listener_status_subscribers
-            .lock()
+        self.runtime
+            .block_on(self.listener_status_subscribers.lock())
             .map_err(|_| "failed to lock MQTT listener subscribers".to_string())?
             .push(tx);
         Ok(rx)
     }
 
-    #[cfg(feature = "std")]
     fn broadcast_listener_status(&self, status: MqttListenerStatus) -> Result<(), String> {
         let mut subscribers = self
-            .listener_status_subscribers
-            .lock()
+            .runtime
+            .block_on(self.listener_status_subscribers.lock())
             .map_err(|_| "failed to lock MQTT listener subscribers".to_string())?;
-        subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
+        subscribers.retain(|subscriber| {
+            !matches!(
+                subscriber.try_send(status.clone()),
+                Err(ChannelError::Closed)
+            )
+        });
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     async fn send_listener_command(
         &self,
         command: SessionCommand,
@@ -511,6 +477,7 @@ impl MqttDriver {
         let sender = self
             .listener_command_sender
             .lock()
+            .await
             .map_err(|_| "failed to lock MQTT listener command sender".to_string())?
             .clone()
             .ok_or_else(|| "MQTT listener command path is not initialized".to_string())?;
@@ -522,13 +489,14 @@ impl MqttDriver {
             .await
             .map_err(|_| "failed to send MQTT command to listener".to_string())?;
 
-        let deadline = std::time::Instant::now()
-            + std::time::Duration::from_millis(MQTT_LISTENER_COMMAND_TIMEOUT_MS);
+        let deadline = self.runtime.now();
         loop {
             match response_rx.try_recv() {
                 Ok(result) => return result,
                 Err(ChannelError::Empty) => {
-                    if std::time::Instant::now() >= deadline {
+                    if deadline.elapsed()
+                        >= core::time::Duration::from_millis(MQTT_LISTENER_COMMAND_TIMEOUT_MS)
+                    {
                         return Err("MQTT listener command timed out".to_string());
                     }
                     self.runtime
@@ -545,18 +513,18 @@ impl MqttDriver {
         }
     }
 
-    #[cfg(feature = "std")]
     async fn take_session_wait_async(&self) -> Result<MqttClientSession, String> {
         loop {
             {
                 let mut guard = self
                     .session
                     .lock()
+                    .await
                     .map_err(|_| "failed to lock MQTT session".to_string())?;
                 if let Some(session) = guard.take() {
                     return Ok(session);
                 }
-                if !self.listener_running.load(Ordering::SeqCst) {
+                if !self.listener_running.load(AtomicOrdering::SeqCst) {
                     return Err("MQTT session not initialized".to_string());
                 }
             }
@@ -567,28 +535,27 @@ impl MqttDriver {
         }
     }
 
-    #[cfg(feature = "std")]
-    fn restore_session(&self, session: MqttClientSession) -> Result<(), String> {
+    async fn restore_session(&self, session: MqttClientSession) -> Result<(), String> {
         let mut guard = self
             .session
             .lock()
+            .await
             .map_err(|_| "failed to lock MQTT session".to_string())?;
         *guard = Some(session);
         Ok(())
     }
 
-    #[cfg(feature = "std")]
-    fn clear_session(&self) -> Result<(), String> {
+    async fn clear_session(&self) -> Result<(), String> {
         let mut guard = self
             .session
             .lock()
+            .await
             .map_err(|_| "failed to lock MQTT session".to_string())?;
         *guard = None;
         Ok(())
     }
 }
 
-#[cfg(feature = "std")]
 #[derive(Debug)]
 enum SessionCommandKind {
     Publish(MqttPacketRequest),
@@ -596,88 +563,101 @@ enum SessionCommandKind {
     Unsubscribe(MqttPacketRequest),
 }
 
-#[cfg(feature = "std")]
 struct SessionCommand {
     kind: SessionCommandKind,
     response: Option<RuntimeSender<Result<SessionCommandResult, String>>>,
 }
 
-#[cfg(feature = "std")]
 impl SessionCommand {
-    fn with_response(mut self, response: RuntimeSender<Result<SessionCommandResult, String>>) -> Self {
+    fn with_response(
+        mut self,
+        response: RuntimeSender<Result<SessionCommandResult, String>>,
+    ) -> Self {
         self.response = Some(response);
         self
     }
 }
 
-#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 enum SessionCommandResult {
     Done,
     Events(Vec<RoutedEvent>),
 }
 
-#[cfg(feature = "std")]
-fn broadcast_listener_status_to_subscribers(
-    subscribers: &Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
+async fn broadcast_listener_status_to_subscribers(
+    subscribers: &Shared<RuntimeMutex<Vec<RuntimeSender<MqttListenerStatus>>>>,
     status: MqttListenerStatus,
 ) {
-    if let Ok(mut subscribers) = subscribers.lock() {
-        subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
+    if let Ok(mut subscribers) = subscribers.lock().await {
+        subscribers.retain(|subscriber| {
+            !matches!(
+                subscriber.try_send(status.clone()),
+                Err(ChannelError::Closed)
+            )
+        });
     }
 }
 
-#[cfg(feature = "std")]
 async fn process_session_command(
+    runtime: &StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
     command: SessionCommand,
 ) -> Result<(), String> {
     let response = match command.kind {
-        SessionCommandKind::Publish(request) => async {
-            send_packet_request_async(session, device_id, request).await?;
-            let _ = read_from_session_async(
-                session,
-                device_id,
-                None,
-                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
-            )
-            .await?;
-            Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+        SessionCommandKind::Publish(request) => {
+            async {
+                send_packet_request_async(runtime, session, device_id, request).await?;
+                let _ = read_from_session_async(
+                    runtime,
+                    session,
+                    device_id,
+                    None,
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                )
+                .await?;
+                Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+            }
+            .await
         }
-        .await,
-        SessionCommandKind::Subscribe(request) => async {
-            send_packet_request_async(session, device_id, request).await?;
-            let messages = read_from_session_async(
-                session,
-                device_id,
-                None,
-                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
-            )
-            .await?;
-            Ok::<SessionCommandResult, String>(SessionCommandResult::Events(
-                messages
-                    .into_iter()
-                    .filter_map(|message| match message {
-                        RoutedMessage::Event(event) => Some(event),
-                        _ => None,
-                    })
-                    .collect(),
-            ))
+        SessionCommandKind::Subscribe(request) => {
+            async {
+                send_packet_request_async(runtime, session, device_id, request).await?;
+                let messages = read_from_session_async(
+                    runtime,
+                    session,
+                    device_id,
+                    None,
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                )
+                .await?;
+                Ok::<SessionCommandResult, String>(SessionCommandResult::Events(
+                    messages
+                        .into_iter()
+                        .filter_map(|message| match message {
+                            RoutedMessage::Event(event) => Some(event),
+                            _ => None,
+                        })
+                        .collect(),
+                ))
+            }
+            .await
         }
-        .await,
-        SessionCommandKind::Unsubscribe(request) => async {
-            send_packet_request_async(session, device_id, request).await?;
-            let _ = read_from_session_async(
-                session,
-                device_id,
-                None,
-                Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
-            )
-            .await?;
-            Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+        SessionCommandKind::Unsubscribe(request) => {
+            async {
+                send_packet_request_async(runtime, session, device_id, request).await?;
+                let _ = read_from_session_async(
+                    runtime,
+                    session,
+                    device_id,
+                    None,
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                )
+                .await?;
+                Ok::<SessionCommandResult, String>(SessionCommandResult::Done)
+            }
+            .await
         }
-        .await,
     };
 
     if let Some(response_tx) = command.response {
@@ -690,7 +670,6 @@ impl Lifecycle for MqttDriver {
     type Error = String;
 
     async fn start(&self) -> Result<(), Self::Error> {
-        #[cfg(feature = "std")]
         {
             return self.ensure_connected_async().await;
         }
@@ -700,18 +679,18 @@ impl Lifecycle for MqttDriver {
     }
 
     async fn stop(&self) -> Result<(), Self::Error> {
-        #[cfg(feature = "std")]
         {
             self.stop_listener()?;
             let maybe_session = {
                 let mut guard = self
                     .session
                     .lock()
+                    .await
                     .map_err(|_| "failed to lock MQTT session".to_string())?;
                 guard.take()
             };
             if let Some(mut session) = maybe_session {
-                let _ = disconnect_session(&mut session).await;
+                let _ = disconnect_session(&self.runtime, &mut session).await;
             }
             self.broadcast_listener_status(self.listener_status()?)?;
             return Ok(());
@@ -728,9 +707,8 @@ impl PubSub for MqttDriver {
     type Error = String;
 
     async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
-        #[cfg(feature = "std")]
         {
-            if self.listener_running.load(Ordering::SeqCst) {
+            if self.listener_running.load(AtomicOrdering::SeqCst) {
                 match self
                     .send_listener_command(SessionCommand {
                         kind: SessionCommandKind::Publish(request.clone()),
@@ -753,22 +731,29 @@ impl PubSub for MqttDriver {
             }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, request.clone()).await?;
+                send_packet_request_async(
+                    &self.runtime,
+                    &mut session,
+                    &self.dvc.id,
+                    request.clone(),
+                )
+                .await?;
                 let _ = read_from_session_async(
+                    &self.runtime,
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
-                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
                 Ok::<(), String>(())
             }
             .await;
             if result.is_ok() {
-                self.restore_session(session)?;
+                self.restore_session(session).await?;
             } else {
-                self.clear_session()?;
-                if self.listener_running.load(Ordering::SeqCst) {
+                self.clear_session().await?;
+                if self.listener_running.load(AtomicOrdering::SeqCst) {
                     let _ = self.enqueue_recovery_request(request);
                     return Ok(());
                 }
@@ -789,10 +774,9 @@ impl PubSub for MqttDriver {
     where
         S: EventSink<Event = RoutedEvent> + Send,
     {
-        #[cfg(feature = "std")]
         {
             self.track_subscription_intent(&subscription)?;
-            if self.listener_running.load(Ordering::SeqCst) {
+            if self.listener_running.load(AtomicOrdering::SeqCst) {
                 match self
                     .send_listener_command(SessionCommand {
                         kind: SessionCommandKind::Subscribe(subscription.clone()),
@@ -822,21 +806,28 @@ impl PubSub for MqttDriver {
             }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, subscription.clone()).await?;
+                send_packet_request_async(
+                    &self.runtime,
+                    &mut session,
+                    &self.dvc.id,
+                    subscription.clone(),
+                )
+                .await?;
                 read_from_session_async(
+                    &self.runtime,
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
-                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await
             }
             .await;
             if result.is_ok() {
-                self.restore_session(session)?;
+                self.restore_session(session).await?;
             } else {
-                self.clear_session()?;
-                if self.listener_running.load(Ordering::SeqCst) {
+                self.clear_session().await?;
+                if self.listener_running.load(AtomicOrdering::SeqCst) {
                     let _ = self.enqueue_recovery_request(subscription);
                     return Ok(());
                 }
@@ -857,10 +848,9 @@ impl PubSub for MqttDriver {
     }
 
     async fn unsubscribe(&self, subscription: Self::Subscription) -> Result<(), Self::Error> {
-        #[cfg(feature = "std")]
         {
             self.track_subscription_intent(&subscription)?;
-            if self.listener_running.load(Ordering::SeqCst) {
+            if self.listener_running.load(AtomicOrdering::SeqCst) {
                 match self
                     .send_listener_command(SessionCommand {
                         kind: SessionCommandKind::Unsubscribe(subscription.clone()),
@@ -884,22 +874,29 @@ impl PubSub for MqttDriver {
             }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, subscription.clone()).await?;
+                send_packet_request_async(
+                    &self.runtime,
+                    &mut session,
+                    &self.dvc.id,
+                    subscription.clone(),
+                )
+                .await?;
                 let _ = read_from_session_async(
+                    &self.runtime,
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
-                    Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
+                    Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
                 Ok::<(), String>(())
             }
             .await;
             if result.is_ok() {
-                self.restore_session(session)?;
+                self.restore_session(session).await?;
             } else {
-                self.clear_session()?;
-                if self.listener_running.load(Ordering::SeqCst) {
+                self.clear_session().await?;
+                if self.listener_running.load(AtomicOrdering::SeqCst) {
                     let _ = self.enqueue_recovery_request(subscription);
                     return Ok(());
                 }
@@ -921,31 +918,33 @@ impl EventSource for MqttDriver {
     where
         S: EventSink<Event = Self::Event> + Send + 'static,
     {
-        #[cfg(feature = "std")]
         {
             self.ensure_connected_async().await?;
-            if self.listener_running.swap(true, Ordering::SeqCst) {
+            if self.listener_running.swap(true, AtomicOrdering::SeqCst) {
                 return Err("MQTT listener already running".to_string());
             }
 
-            let session = Arc::clone(&self.session);
-            let running = Arc::clone(&self.listener_running);
-            let listener_error = Arc::clone(&self.listener_error);
-            let status_subscribers = Arc::clone(&self.listener_status_subscribers);
-            let listener_command_sender = Arc::clone(&self.listener_command_sender);
-            let negotiated_connack = Arc::clone(&self.negotiated_connack);
+            let session = Shared::clone(&self.session);
+            let running = Shared::clone(&self.listener_running);
+            let listener_error = Shared::clone(&self.listener_error);
+            let status_subscribers = Shared::clone(&self.listener_status_subscribers);
+            let listener_command_sender = Shared::clone(&self.listener_command_sender);
+            let negotiated_connack = Shared::clone(&self.negotiated_connack);
             let device_id = self.dvc.id.clone();
             let driver = self.clone();
             let runtime = self.runtime.clone();
             let reconnect = self.reconnect_config()?;
-            let (command_tx, command_rx): (RuntimeSender<SessionCommand>, RuntimeReceiver<SessionCommand>) =
-                runtime.channel(MQTT_LISTENER_COMMAND_CHANNEL_CAPACITY);
+            let (command_tx, command_rx): (
+                RuntimeSender<SessionCommand>,
+                RuntimeReceiver<SessionCommand>,
+            ) = runtime.channel(MQTT_LISTENER_COMMAND_CHANNEL_CAPACITY);
             self.clear_listener_error()?;
             self.broadcast_listener_status(MqttListenerStatus::Running)?;
             {
                 let mut sender_guard = self
                     .listener_command_sender
                     .lock()
+                    .await
                     .map_err(|_| "failed to lock MQTT listener command sender".to_string())?;
                 *sender_guard = Some(command_tx);
             }
@@ -954,22 +953,22 @@ impl EventSource for MqttDriver {
                 let mut reconnect_attempt = 0u32;
                 let mut command_rx = command_rx;
 
-                'listen: while running.load(Ordering::SeqCst) {
+                'listen: while running.load(AtomicOrdering::SeqCst) {
                     let mut session_value = match {
-                        let mut guard = match session.lock() {
+                        let mut guard = match session.lock().await {
                             Ok(guard) => guard,
                             Err(_) => {
-                                if let Ok(mut error_guard) = listener_error.lock() {
+                                if let Ok(mut error_guard) = listener_error.lock().await {
                                     *error_guard = Some(
                                         "failed to lock MQTT session while listening".to_string(),
                                     );
                                 }
                                 broadcast_listener_status_to_subscribers(
-                                    &status_subscribers,
-                                    MqttListenerStatus::Failed(
-                                        "failed to lock MQTT session while listening".to_string(),
-                                    ),
-                                );
+                                        &status_subscribers,
+                                        MqttListenerStatus::Failed(
+                                            "failed to lock MQTT session while listening".to_string(),
+                                        ),
+                                ).await;
                                 break;
                             }
                         };
@@ -988,14 +987,14 @@ impl EventSource for MqttDriver {
                         match command_rx.try_recv() {
                             Ok(command) => {
                                 if let Err(error) =
-                                    process_session_command(&mut session_value, &device_id, command)
+                                    process_session_command(&runtime, &mut session_value, &device_id, command)
                                         .await
                                 {
-                                    if let Ok(mut guard) = session.lock() {
+                                    if let Ok(mut guard) = session.lock().await {
                                         *guard = None;
                                     }
                                     let mut error = error;
-                                    while running.load(Ordering::SeqCst) {
+                                    while running.load(AtomicOrdering::SeqCst) {
                                         reconnect_attempt = reconnect_attempt.saturating_add(1);
                                         if !reconnect.allows_attempt(reconnect_attempt) {
                                             break;
@@ -1007,14 +1006,14 @@ impl EventSource for MqttDriver {
                                             ))
                                             .await;
 
-                                        if !running.load(Ordering::SeqCst) {
+                                        if !running.load(AtomicOrdering::SeqCst) {
                                             break;
                                         }
 
                                         match driver.ensure_connected_async().await {
                                             Ok(()) => {
                                                 let maybe_reconnected_session = {
-                                                    let mut guard = match session.lock() {
+                                                    let mut guard = match session.lock().await {
                                                         Ok(guard) => guard,
                                                         Err(_) => {
                                                             error = "failed to lock MQTT session after reconnect".to_string();
@@ -1037,7 +1036,7 @@ impl EventSource for MqttDriver {
                                                 {
                                                     Ok(recovered_events) => recovered_events,
                                                     Err(recovery_error) => {
-                                                        if let Ok(mut guard) = session.lock() {
+                                                        if let Ok(mut guard) = session.lock().await {
                                                             *guard = None;
                                                         }
                                                         error = recovery_error;
@@ -1045,13 +1044,12 @@ impl EventSource for MqttDriver {
                                                     }
                                                 };
 
-                                                if let Ok(mut guard) = session.lock() {
+                                                if let Ok(mut guard) = session.lock().await {
                                                     *guard = Some(reconnected_session);
                                                 }
                                                 for event in recovered_events {
                                                     if sink.handle(event).is_err() {
-                                                        if let Ok(mut error_guard) =
-                                                            listener_error.lock()
+                                                        if let Ok(mut error_guard) = listener_error.lock().await
                                                         {
                                                             *error_guard = Some(
                                                                 "failed to forward MQTT event to sink"
@@ -1064,13 +1062,13 @@ impl EventSource for MqttDriver {
                                                                 "failed to forward MQTT event to sink"
                                                                     .to_string(),
                                                             ),
-                                                        );
-                                                        running.store(false, Ordering::SeqCst);
+                                                        ).await;
+                                                        running.store(false, AtomicOrdering::SeqCst);
                                                         break 'listen;
                                                     }
                                                 }
                                                 reconnect_attempt = 0;
-                                                if let Ok(mut error_guard) = listener_error.lock() {
+                                                if let Ok(mut error_guard) = listener_error.lock().await {
                                                     *error_guard = None;
                                                 }
                                                 continue 'listen;
@@ -1080,17 +1078,17 @@ impl EventSource for MqttDriver {
                                             }
                                         }
                                     }
-                                    if !running.load(Ordering::SeqCst) {
+                                    if !running.load(AtomicOrdering::SeqCst) {
                                         break 'listen;
                                     }
-                                    if let Ok(mut error_guard) = listener_error.lock() {
+                                    if let Ok(mut error_guard) = listener_error.lock().await {
                                         *error_guard = Some(error.clone());
                                     }
                                     broadcast_listener_status_to_subscribers(
                                         &status_subscribers,
                                         MqttListenerStatus::Failed(error),
-                                    );
-                                    running.store(false, Ordering::SeqCst);
+                                    ).await;
+                                    running.store(false, AtomicOrdering::SeqCst);
                                     break 'listen;
                                 }
                             }
@@ -1103,23 +1101,24 @@ impl EventSource for MqttDriver {
                     }
 
                     let messages = read_from_session_async(
+                        &runtime,
                         &mut session_value,
                         &device_id,
                         Some(&negotiated_connack),
-                        Some(std::time::Duration::from_millis(MQTT_LISTENER_IDLE_POLL_MS)),
+                        Some(core::time::Duration::from_millis(MQTT_LISTENER_IDLE_POLL_MS)),
                     )
                     .await;
 
                     match messages {
                         Ok(messages) => {
                             reconnect_attempt = 0;
-                            if let Ok(mut guard) = session.lock() {
+                            if let Ok(mut guard) = session.lock().await {
                                 *guard = Some(session_value);
                             }
                             for message in messages {
                                 if let RoutedMessage::Event(event) = message {
                                     if sink.handle(event).is_err() {
-                                        if let Ok(mut error_guard) = listener_error.lock() {
+                                        if let Ok(mut error_guard) = listener_error.lock().await {
                                             *error_guard = Some(
                                                 "failed to forward MQTT event to sink".to_string(),
                                             );
@@ -1129,18 +1128,18 @@ impl EventSource for MqttDriver {
                                             MqttListenerStatus::Failed(
                                                 "failed to forward MQTT event to sink".to_string(),
                                             ),
-                                        );
-                                        running.store(false, Ordering::SeqCst);
+                                        ).await;
+                                        running.store(false, AtomicOrdering::SeqCst);
                                         break;
                                     }
                                 }
                             }
                         }
                         Err(mut error) => {
-                            if let Ok(mut guard) = session.lock() {
+                            if let Ok(mut guard) = session.lock().await {
                                 *guard = None;
                             }
-                            while running.load(Ordering::SeqCst) {
+                            while running.load(AtomicOrdering::SeqCst) {
                                 reconnect_attempt = reconnect_attempt.saturating_add(1);
                                 if !reconnect.allows_attempt(reconnect_attempt) {
                                     break;
@@ -1152,14 +1151,14 @@ impl EventSource for MqttDriver {
                                     ))
                                     .await;
 
-                                if !running.load(Ordering::SeqCst) {
+                                if !running.load(AtomicOrdering::SeqCst) {
                                     break;
                                 }
 
                                 match driver.ensure_connected_async().await {
                                     Ok(()) => {
                                         let maybe_reconnected_session = {
-                                            let mut guard = match session.lock() {
+                                            let mut guard = match session.lock().await {
                                                 Ok(guard) => guard,
                                                 Err(_) => {
                                                     error =
@@ -1183,18 +1182,18 @@ impl EventSource for MqttDriver {
                                             )
                                             .await
                                         {
-                                            if let Ok(mut guard) = session.lock() {
+                                            if let Ok(mut guard) = session.lock().await {
                                                 *guard = None;
                                             }
                                             error = recovery_error;
                                             continue;
                                         }
 
-                                        if let Ok(mut guard) = session.lock() {
+                                        if let Ok(mut guard) = session.lock().await {
                                             *guard = Some(reconnected_session);
                                         }
                                         reconnect_attempt = 0;
-                                        if let Ok(mut error_guard) = listener_error.lock() {
+                                        if let Ok(mut error_guard) = listener_error.lock().await {
                                             *error_guard = None;
                                         }
                                         continue 'listen;
@@ -1204,29 +1203,29 @@ impl EventSource for MqttDriver {
                                     }
                                 }
                             }
-                            if reconnect_attempt == 0 && running.load(Ordering::SeqCst) {
+                            if reconnect_attempt == 0 && running.load(AtomicOrdering::SeqCst) {
                                 continue;
                             }
-                            if !running.load(Ordering::SeqCst) {
+                            if !running.load(AtomicOrdering::SeqCst) {
                                 break;
                             }
-                            if let Ok(mut error_guard) = listener_error.lock() {
+                            if let Ok(mut error_guard) = listener_error.lock().await {
                                 *error_guard = Some(error.clone());
                             }
                             broadcast_listener_status_to_subscribers(
                                 &status_subscribers,
                                 MqttListenerStatus::Failed(error),
-                            );
-                            running.store(false, Ordering::SeqCst);
+                            ).await;
+                            running.store(false, AtomicOrdering::SeqCst);
                             break;
                         }
                     }
                 }
-                if let Ok(mut sender_guard) = listener_command_sender.lock() {
+                if let Ok(mut sender_guard) = listener_command_sender.lock().await {
                     *sender_guard = None;
                 }
-                running.store(false, Ordering::SeqCst);
-                let final_status = match listener_error.lock() {
+                running.store(false, AtomicOrdering::SeqCst);
+                let final_status = match listener_error.lock().await {
                     Ok(error_guard) => match error_guard.clone() {
                         Some(error) => MqttListenerStatus::Failed(error),
                         None => MqttListenerStatus::Stopped,
@@ -1235,12 +1234,13 @@ impl EventSource for MqttDriver {
                         "failed to lock MQTT listener error after listener exit".to_string(),
                     ),
                 };
-                broadcast_listener_status_to_subscribers(&status_subscribers, final_status);
+                broadcast_listener_status_to_subscribers(&status_subscribers, final_status).await;
             });
 
             let mut handle_guard = self
                 .listener_handle
                 .lock()
+                .await
                 .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
             *handle_guard = Some(handle);
             return Ok(());
@@ -1254,7 +1254,6 @@ impl EventSource for MqttDriver {
     }
 
     async fn stop_listening(&self) -> Result<(), Self::Error> {
-        #[cfg(feature = "std")]
         {
             return self.stop_listener();
         }

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -108,6 +108,9 @@ pub struct MqttDriver {
     /// Live MQTT client session for std-enabled runtime transport.
     #[cfg(feature = "std")]
     session: Arc<Mutex<Option<MqttClientSession>>>,
+    /// Last negotiated CONNACK capabilities and identifiers observed from broker.
+    #[cfg(feature = "std")]
+    negotiated_connack: Arc<Mutex<Option<MqttConnackProperties>>>,
     /// Background listener run flag.
     #[cfg(feature = "std")]
     listener_running: Arc<AtomicBool>,
@@ -152,6 +155,8 @@ impl MqttDriver {
             dvc,
             #[cfg(feature = "std")]
             session: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "std")]
+            negotiated_connack: Arc::new(Mutex::new(None)),
             #[cfg(feature = "std")]
             listener_running: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "std")]
@@ -224,10 +229,17 @@ impl MqttDriver {
             pending_reply_routes: std::collections::HashMap::new(),
         };
         let events = session.connection.checked_send(connect_packet);
-        runtime::handle_connection_events_async(&mut session, &self.dvc.id, events).await?;
+        runtime::handle_connection_events_async(
+            &mut session,
+            &self.dvc.id,
+            Some(&self.negotiated_connack),
+            events,
+        )
+        .await?;
         let _ = read_from_session_async(
             &mut session,
             &self.dvc.id,
+            Some(&self.negotiated_connack),
             Some(std::time::Duration::from_millis(MQTT_CONNECT_IO_TIMEOUT_MS)),
         )
         .await?;
@@ -240,6 +252,15 @@ impl MqttDriver {
             *guard = Some(session);
         }
         Ok(())
+    }
+
+    /// Returns the most recent broker CONNACK negotiation snapshot, if available.
+    #[cfg(feature = "std")]
+    pub fn negotiated_connack(&self) -> Result<Option<MqttConnackProperties>, String> {
+        self.negotiated_connack
+            .lock()
+            .map(|guard| (*guard).clone())
+            .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())
     }
 
     #[cfg(feature = "std")]
@@ -333,6 +354,7 @@ impl MqttDriver {
                     let messages = read_from_session_async(
                         session,
                         &self.dvc.id,
+                        Some(&self.negotiated_connack),
                         Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                     )
                     .await?;
@@ -355,6 +377,7 @@ impl MqttDriver {
                 let messages = read_from_session_async(
                     session,
                     &self.dvc.id,
+                    Some(&self.negotiated_connack),
                     Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -616,6 +639,7 @@ async fn process_session_command(
             let _ = read_from_session_async(
                 session,
                 device_id,
+                None,
                 Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
             )
             .await?;
@@ -627,6 +651,7 @@ async fn process_session_command(
             let messages = read_from_session_async(
                 session,
                 device_id,
+                None,
                 Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
             )
             .await?;
@@ -646,6 +671,7 @@ async fn process_session_command(
             let _ = read_from_session_async(
                 session,
                 device_id,
+                None,
                 Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
             )
             .await?;
@@ -731,6 +757,7 @@ impl PubSub for MqttDriver {
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
+                    Some(&self.negotiated_connack),
                     Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -799,6 +826,7 @@ impl PubSub for MqttDriver {
                 read_from_session_async(
                     &mut session,
                     &self.dvc.id,
+                    Some(&self.negotiated_connack),
                     Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await
@@ -860,6 +888,7 @@ impl PubSub for MqttDriver {
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
+                    Some(&self.negotiated_connack),
                     Some(std::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -904,6 +933,7 @@ impl EventSource for MqttDriver {
             let listener_error = Arc::clone(&self.listener_error);
             let status_subscribers = Arc::clone(&self.listener_status_subscribers);
             let listener_command_sender = Arc::clone(&self.listener_command_sender);
+            let negotiated_connack = Arc::clone(&self.negotiated_connack);
             let device_id = self.dvc.id.clone();
             let driver = self.clone();
             let runtime = self.runtime.clone();
@@ -1075,6 +1105,7 @@ impl EventSource for MqttDriver {
                     let messages = read_from_session_async(
                         &mut session_value,
                         &device_id,
+                        Some(&negotiated_connack),
                         Some(std::time::Duration::from_millis(MQTT_LISTENER_IDLE_POLL_MS)),
                     )
                     .await;

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -307,15 +307,27 @@ impl MqttDriver {
         subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
         Ok(())
     }
+
     #[cfg(feature = "std")]
-    fn take_session(&self) -> Result<MqttClientSession, String> {
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        guard
-            .take()
-            .ok_or_else(|| "MQTT session not initialized".to_string())
+    async fn take_session_wait_async(&self) -> Result<MqttClientSession, String> {
+        loop {
+            {
+                let mut guard = self
+                    .session
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT session".to_string())?;
+                if let Some(session) = guard.take() {
+                    return Ok(session);
+                }
+                if !self.listener_running.load(Ordering::SeqCst) {
+                    return Err("MQTT session not initialized".to_string());
+                }
+            }
+
+            self.runtime
+                .sleep(core::time::Duration::from_millis(10))
+                .await;
+        }
     }
 
     #[cfg(feature = "std")]
@@ -325,6 +337,16 @@ impl MqttDriver {
             .lock()
             .map_err(|_| "failed to lock MQTT session".to_string())?;
         *guard = Some(session);
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn clear_session(&self) -> Result<(), String> {
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        *guard = None;
         Ok(())
     }
 }
@@ -384,7 +406,7 @@ impl PubSub for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.ensure_connected_async().await?;
-            let mut session = self.take_session()?;
+            let mut session = self.take_session_wait_async().await?;
             let result = async {
                 send_packet_request_async(&mut session, &self.dvc.id, request).await?;
                 let _ = read_from_session_async(
@@ -396,7 +418,11 @@ impl PubSub for MqttDriver {
                 Ok::<(), String>(())
             }
             .await;
-            self.restore_session(session)?;
+            if result.is_ok() {
+                self.restore_session(session)?;
+            } else {
+                self.clear_session()?;
+            }
             result?;
             return Ok(());
         }
@@ -416,7 +442,7 @@ impl PubSub for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.ensure_connected_async().await?;
-            let mut session = self.take_session()?;
+            let mut session = self.take_session_wait_async().await?;
             let result = async {
                 send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
                 read_from_session_async(
@@ -427,7 +453,11 @@ impl PubSub for MqttDriver {
                 .await
             }
             .await;
-            self.restore_session(session)?;
+            if result.is_ok() {
+                self.restore_session(session)?;
+            } else {
+                self.clear_session()?;
+            }
             let messages = result?;
             let mut sink = sink;
             for message in messages {
@@ -447,7 +477,7 @@ impl PubSub for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.ensure_connected_async().await?;
-            let mut session = self.take_session()?;
+            let mut session = self.take_session_wait_async().await?;
             let result = async {
                 send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
                 let _ = read_from_session_async(
@@ -459,7 +489,11 @@ impl PubSub for MqttDriver {
                 Ok::<(), String>(())
             }
             .await;
-            self.restore_session(session)?;
+            if result.is_ok() {
+                self.restore_session(session)?;
+            } else {
+                self.clear_session()?;
+            }
             result?;
             return Ok(());
         }
@@ -497,7 +531,7 @@ impl EventSource for MqttDriver {
                 let mut sink = sink;
 
                 while running.load(Ordering::SeqCst) {
-                    let mut session_value = {
+                    let mut session_value = match {
                         let mut guard = match session.lock() {
                             Ok(guard) => guard,
                             Err(_) => {
@@ -515,23 +549,12 @@ impl EventSource for MqttDriver {
                                 break;
                             }
                         };
-                        match guard.take() {
-                            Some(session) => session,
-                            None => {
-                                if let Ok(mut error_guard) = listener_error.lock() {
-                                    *error_guard = Some(
-                                        "MQTT session missing while listener was running".to_string(),
-                                    );
-                                }
-                                broadcast_listener_status_to_subscribers(
-                                    &status_subscribers,
-                                    MqttListenerStatus::Failed(
-                                        "MQTT session missing while listener was running"
-                                            .to_string(),
-                                    ),
-                                );
-                                break;
-                            }
+                        guard.take()
+                    } {
+                        Some(session) => session,
+                        None => {
+                            runtime.sleep(core::time::Duration::from_millis(10)).await;
+                            continue;
                         }
                     };
                     let messages = read_from_session_async(
@@ -540,12 +563,12 @@ impl EventSource for MqttDriver {
                         Some(std::time::Duration::from_millis(250)),
                     )
                     .await;
-                    if let Ok(mut guard) = session.lock() {
-                        *guard = Some(session_value);
-                    }
 
                     match messages {
                         Ok(messages) => {
+                            if let Ok(mut guard) = session.lock() {
+                                *guard = Some(session_value);
+                            }
                             for message in messages {
                                 if let RoutedMessage::Event(event) = message {
                                     if sink.handle(event).is_err() {
@@ -567,6 +590,9 @@ impl EventSource for MqttDriver {
                             }
                         }
                         Err(error) => {
+                            if let Ok(mut guard) = session.lock() {
+                                *guard = None;
+                            }
                             if running.load(Ordering::SeqCst)
                                 && driver.ensure_connected_async().await.is_ok()
                             {

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -58,7 +58,7 @@ use types::{MqttPacketRequest, MqttResourceAttributes};
 #[cfg(feature = "std")]
 use runtime::{
     MqttClientSession, build_connect_packet, handle_connection_events, mqtt_version_from_core,
-    normalize_broker_addr, read_from_session, send_packet_request,
+    normalize_broker_addr, read_from_session, send_packet_request, disconnect_session,
 };
 
 pub use types::{
@@ -76,9 +76,6 @@ pub enum MqttListenerStatus {
     Failed(String),
 }
 
-#[cfg(feature = "std")]
-const MQTT_LISTENER_EVENT_BUFFER_CAPACITY: usize = 256;
-
 /// MQTT adapter backed by `mqtt_protocol_core` packet builders.
 ///
 /// In `std` builds this type also owns the live TCP session and background listener runtime.
@@ -94,7 +91,7 @@ pub struct MqttDriver {
     /// Background listener run flag.
     #[cfg(feature = "std")]
     listener_running: Arc<AtomicBool>,
-    /// Background listener thread handle.
+    /// Background listener task handle.
     #[cfg(feature = "std")]
     listener_handle: Arc<Mutex<Option<RuntimeTask<()>>>>,
     /// Last background listener failure, if any.
@@ -103,10 +100,10 @@ pub struct MqttDriver {
     /// Subscribers interested in listener status transitions.
     #[cfg(feature = "std")]
     listener_status_subscribers: Arc<Mutex<Vec<mpsc::Sender<MqttListenerStatus>>>>,
-    /// Std compatibility runtime used for background tasks and bounded channels.
+    /// Selected runtime used for background tasks.
     #[cfg(feature = "std")]
     runtime: Arc<StackRuntime>,
-    /// Std compatibility network adapter used for outbound sockets.
+    /// Selected network adapter used for outbound sockets.
     #[cfg(feature = "std")]
     net: StackNet,
 }
@@ -203,6 +200,10 @@ impl MqttDriver {
         let mut session = MqttClientSession {
             stream,
             connection,
+            protocol_version: config.preferred_protocol_version(),
+            keepalive_secs: config.keepalive_secs,
+            last_activity: std::time::Instant::now(),
+            awaiting_pingresp: false,
             pending_command_ids: std::collections::HashMap::new(),
             pending_reply_routes: std::collections::HashMap::new(),
         };
@@ -234,7 +235,7 @@ impl MqttDriver {
                     .lock()
                     .map_err(|_| "failed to lock MQTT listener error".to_string())?;
                 if error_guard.is_none() {
-                    *error_guard = Some("MQTT listener thread panicked".to_string());
+                    *error_guard = Some("MQTT listener task panicked".to_string());
                 }
             }
         }
@@ -243,36 +244,58 @@ impl MqttDriver {
     }
 
     /// Returns the last background listener error captured by the runtime, if any.
-    #[cfg(feature = "std")]
     pub fn last_listener_error(&self) -> Result<Option<String>, String> {
-        self.listener_error
-            .lock()
-            .map(|error| error.clone())
-            .map_err(|_| "failed to lock MQTT listener error".to_string())
+        #[cfg(feature = "std")]
+        {
+            return self
+                .listener_error
+                .lock()
+                .map(|error| error.clone())
+                .map_err(|_| "failed to lock MQTT listener error".to_string());
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            Ok(None)
+        }
     }
 
     /// Clears any previously captured background listener error.
-    #[cfg(feature = "std")]
     pub fn clear_listener_error(&self) -> Result<(), String> {
-        let mut guard = self
-            .listener_error
-            .lock()
-            .map_err(|_| "failed to lock MQTT listener error".to_string())?;
-        *guard = None;
-        self.broadcast_listener_status(MqttListenerStatus::Stopped)?;
-        Ok(())
+        #[cfg(feature = "std")]
+        {
+            let mut guard = self
+                .listener_error
+                .lock()
+                .map_err(|_| "failed to lock MQTT listener error".to_string())?;
+            *guard = None;
+            self.broadcast_listener_status(MqttListenerStatus::Stopped)?;
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            Ok(())
+        }
     }
 
     /// Returns high-level background listener status for this MQTT driver.
-    #[cfg(feature = "std")]
     pub fn listener_status(&self) -> Result<MqttListenerStatus, String> {
-        if self.listener_running.load(Ordering::SeqCst) {
-            return Ok(MqttListenerStatus::Running);
+        #[cfg(feature = "std")]
+        {
+            if self.listener_running.load(Ordering::SeqCst) {
+                return Ok(MqttListenerStatus::Running);
+            }
+
+            return match self.last_listener_error()? {
+                Some(error) => Ok(MqttListenerStatus::Failed(error)),
+                None => Ok(MqttListenerStatus::Stopped),
+            };
         }
 
-        match self.last_listener_error()? {
-            Some(error) => Ok(MqttListenerStatus::Failed(error)),
-            None => Ok(MqttListenerStatus::Stopped),
+        #[cfg(not(feature = "std"))]
+        {
+            Ok(MqttListenerStatus::Stopped)
         }
     }
 
@@ -298,6 +321,18 @@ impl MqttDriver {
             .map_err(|_| "failed to lock MQTT listener subscribers".to_string())?;
         subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
         Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn reconnect_session(&self) -> Result<(), String> {
+        {
+            let mut guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            *guard = None;
+        }
+        self.ensure_connected()
     }
 }
 
@@ -332,6 +367,9 @@ impl Lifecycle for MqttDriver {
                 .session
                 .lock()
                 .map_err(|_| "failed to lock MQTT session".to_string())?;
+            if let Some(session) = guard.as_mut() {
+                let _ = self.runtime.block_on(disconnect_session(session));
+            }
             *guard = None;
             self.broadcast_listener_status(self.listener_status()?)?;
             return Ok(());
@@ -460,41 +498,12 @@ impl EventSource for MqttDriver {
             let listener_error = Arc::clone(&self.listener_error);
             let status_subscribers = Arc::clone(&self.listener_status_subscribers);
             let device_id = self.dvc.id.clone();
+            let driver = self.clone();
             let runtime = self.runtime.clone();
             self.clear_listener_error()?;
             self.broadcast_listener_status(MqttListenerStatus::Running)?;
             let handle = runtime.clone().spawn(async move {
-                let (event_tx, mut event_rx) =
-                    runtime.channel::<RoutedEvent>(MQTT_LISTENER_EVENT_BUFFER_CAPACITY);
-                let sink_running = Arc::clone(&running);
-                let sink_listener_error = Arc::clone(&listener_error);
-                let sink_status_subscribers = Arc::clone(&status_subscribers);
-                let sink_runtime = runtime.clone();
-                let mut sink_handle = sink_runtime.spawn(async move {
-                    let mut sink = sink;
-                    loop {
-                        match event_rx.recv().await {
-                            Ok(event) => {
-                                if sink.handle(event).is_err() {
-                                    if let Ok(mut error_guard) = sink_listener_error.lock() {
-                                        *error_guard =
-                                            Some("failed to forward MQTT event to sink".to_string());
-                                    }
-                                    broadcast_listener_status_to_subscribers(
-                                        &sink_status_subscribers,
-                                        MqttListenerStatus::Failed(
-                                            "failed to forward MQTT event to sink".to_string(),
-                                        ),
-                                    );
-                                    sink_running.store(false, Ordering::SeqCst);
-                                    break;
-                                }
-                            }
-                            Err(ChannelError::Closed | ChannelError::RuntimeUnavailable) => break,
-                            Err(ChannelError::Full) => {}
-                        }
-                    }
-                });
+                let mut sink = sink;
 
                 while running.load(Ordering::SeqCst) {
                     let messages = {
@@ -545,50 +554,31 @@ impl EventSource for MqttDriver {
                         Ok(messages) => {
                             for message in messages {
                                 if let RoutedMessage::Event(event) = message {
-                                    match event_tx.try_send(event) {
-                                        Ok(()) => {}
-                                        Err(ChannelError::Full) => {
-                                            if let Ok(mut error_guard) = listener_error.lock() {
-                                                *error_guard = Some(
-                                                    "MQTT listener event backlog exceeded"
-                                                        .to_string(),
-                                                );
-                                            }
-                                            broadcast_listener_status_to_subscribers(
-                                                &status_subscribers,
-                                                MqttListenerStatus::Failed(
-                                                    "MQTT listener event backlog exceeded"
-                                                        .to_string(),
-                                                ),
+                                    if sink.handle(event).is_err() {
+                                        if let Ok(mut error_guard) = listener_error.lock() {
+                                            *error_guard = Some(
+                                                "failed to forward MQTT event to sink".to_string(),
                                             );
-                                            running.store(false, Ordering::SeqCst);
-                                            break;
                                         }
-                                        Err(
-                                            ChannelError::Closed
-                                                | ChannelError::RuntimeUnavailable,
-                                        ) => {
-                                            if let Ok(mut error_guard) = listener_error.lock() {
-                                                *error_guard = Some(
-                                                    "MQTT listener sink worker disconnected"
-                                                        .to_string(),
-                                                );
-                                            }
-                                            broadcast_listener_status_to_subscribers(
-                                                &status_subscribers,
-                                                MqttListenerStatus::Failed(
-                                                    "MQTT listener sink worker disconnected"
-                                                        .to_string(),
-                                                ),
-                                            );
-                                            running.store(false, Ordering::SeqCst);
-                                            break;
-                                        }
+                                        broadcast_listener_status_to_subscribers(
+                                            &status_subscribers,
+                                            MqttListenerStatus::Failed(
+                                                "failed to forward MQTT event to sink".to_string(),
+                                            ),
+                                        );
+                                        running.store(false, Ordering::SeqCst);
+                                        break;
                                     }
                                 }
                             }
                         }
                         Err(error) => {
+                            if running.load(Ordering::SeqCst) && driver.reconnect_session().is_ok() {
+                                if let Ok(mut error_guard) = listener_error.lock() {
+                                    *error_guard = None;
+                                }
+                                continue;
+                            }
                             if let Ok(mut error_guard) = listener_error.lock() {
                                 *error_guard = Some(error.clone());
                             }
@@ -602,8 +592,6 @@ impl EventSource for MqttDriver {
                     }
                 }
                 running.store(false, Ordering::SeqCst);
-                drop(event_tx);
-                let _ = runtime.block_on(sink_handle.join());
                 let final_status = match listener_error.lock() {
                     Ok(error_guard) => match error_guard.clone() {
                         Some(error) => MqttListenerStatus::Failed(error),

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -1,13 +1,7 @@
-#![cfg_attr(not(feature = "std"), no_std)]
 //! MQTT protocol adapter for ferredge.
 
-#[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "std")]
-use std::string::{String, ToString};
-
-#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
 
 use ferredge_core::prelude::*;
@@ -58,8 +52,12 @@ use runtime::{
 };
 
 pub use types::{
+    MqttAuthChallenge, MqttAuthFlowReason, MqttAuthProvider, MqttAuthResponse, MqttAuthStage,
     MqttCommandConversionError, MqttPublishRequest, MqttSubscriptionRequest, MqttWirePacket,
 };
+
+#[cfg(feature = "std")]
+type MqttAuthHandler = Shared<dyn MqttAuthProvider>;
 
 const MQTT_CONNECT_IO_TIMEOUT_MS: u64 = 1_000;
 const MQTT_ACK_READ_TIMEOUT_MS: u64 = 250;
@@ -110,6 +108,8 @@ pub struct MqttDriver {
     desired_subscriptions: Shared<RuntimeMutex<Map<String, MqttPacketRequest>>>,
     /// Queued outbound requests waiting for broker recovery.
     recovery_queue: Shared<RuntimeMutex<VecDeque<MqttPacketRequest>>>,
+    /// Optional enhanced authentication callback for MQTT v5 AUTH flow.
+    auth_handler: Shared<RuntimeMutex<Option<MqttAuthHandler>>>,
 }
 
 impl core::fmt::Debug for MqttDriver {
@@ -138,7 +138,21 @@ impl MqttDriver {
             net: StackNet::default(),
             desired_subscriptions: Shared::new(runtime.mutex(Map::new())),
             recovery_queue: Shared::new(runtime.mutex(VecDeque::new())),
+            auth_handler: Shared::new(runtime.mutex(None)),
         }
+    }
+
+    /// Registers enhanced MQTT v5 auth callback used for connect-time and re-auth exchanges.
+    pub fn set_auth_handler<P>(&self, handler: P) -> Result<(), String>
+    where
+        P: MqttAuthProvider + 'static,
+    {
+        let mut guard = self
+            .runtime
+            .block_on(self.auth_handler.lock())
+            .map_err(|_| "failed to lock MQTT auth handler".to_string())?;
+        *guard = Some(Shared::new(handler));
+        Ok(())
     }
 
     async fn ensure_connected_async(&self) -> Result<(), String> {
@@ -190,6 +204,7 @@ impl MqttDriver {
             awaiting_pingresp: false,
             pending_command_ids: Map::new(),
             pending_reply_routes: Map::new(),
+            authentication_method: config.connect_properties.authentication_method.clone(),
         };
         let events = session.connection.checked_send(connect_packet);
         runtime::handle_connection_events_async(
@@ -197,19 +212,40 @@ impl MqttDriver {
             &mut session,
             &self.dvc.id,
             Some(&self.negotiated_connack),
+            Some(&self.auth_handler),
             events,
         )
         .await?;
-        let _ = read_from_session_async(
-            &self.runtime,
-            &mut session,
-            &self.dvc.id,
-            Some(&self.negotiated_connack),
-            Some(core::time::Duration::from_millis(
-                MQTT_CONNECT_IO_TIMEOUT_MS,
-            )),
-        )
-        .await?;
+        loop {
+            let _ = read_from_session_async(
+                &self.runtime,
+                &mut session,
+                &self.dvc.id,
+                Some(&self.negotiated_connack),
+                Some(&self.auth_handler),
+                Some(core::time::Duration::from_millis(
+                    MQTT_CONNECT_IO_TIMEOUT_MS,
+                )),
+            )
+            .await?;
+
+            let negotiated = self
+                .negotiated_connack
+                .lock()
+                .await
+                .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())?
+                .clone();
+            if let Some(connack) = negotiated {
+                if connack.reason_code.as_deref() == Some("Success") {
+                    break;
+                }
+                let detail = connack
+                    .reason_string
+                    .clone()
+                    .unwrap_or_else(|| connack.reason_code.clone().unwrap_or_default());
+                return Err(format!("mqtt connect rejected: {detail}"));
+            }
+        }
 
         let mut guard = self
             .session
@@ -322,6 +358,7 @@ impl MqttDriver {
                         session,
                         &self.dvc.id,
                         Some(&self.negotiated_connack),
+                        Some(&self.auth_handler),
                         Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                     )
                     .await?;
@@ -349,6 +386,7 @@ impl MqttDriver {
                     session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
+                    Some(&self.auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -606,6 +644,7 @@ async fn process_session_command(
     runtime: &StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
+    auth_handler: &Shared<RuntimeMutex<Option<MqttAuthHandler>>>,
     command: SessionCommand,
 ) -> Result<(), String> {
     let response = match command.kind {
@@ -617,6 +656,7 @@ async fn process_session_command(
                     session,
                     device_id,
                     None,
+                    Some(auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -632,6 +672,7 @@ async fn process_session_command(
                     session,
                     device_id,
                     None,
+                    Some(auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -655,6 +696,7 @@ async fn process_session_command(
                     session,
                     device_id,
                     None,
+                    Some(auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -747,6 +789,7 @@ impl PubSub for MqttDriver {
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
+                    Some(&self.auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -822,6 +865,7 @@ impl PubSub for MqttDriver {
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
+                    Some(&self.auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await
@@ -890,6 +934,7 @@ impl PubSub for MqttDriver {
                     &mut session,
                     &self.dvc.id,
                     Some(&self.negotiated_connack),
+                    Some(&self.auth_handler),
                     Some(core::time::Duration::from_millis(MQTT_ACK_READ_TIMEOUT_MS)),
                 )
                 .await?;
@@ -934,6 +979,7 @@ impl EventSource for MqttDriver {
             let status_subscribers = Shared::clone(&self.listener_status_subscribers);
             let listener_command_sender = Shared::clone(&self.listener_command_sender);
             let negotiated_connack = Shared::clone(&self.negotiated_connack);
+            let auth_handler = Shared::clone(&self.auth_handler);
             let device_id = self.dvc.id.clone();
             let driver = self.clone();
             let runtime = self.runtime.clone();
@@ -991,7 +1037,13 @@ impl EventSource for MqttDriver {
                         match command_rx.try_recv() {
                             Ok(command) => {
                                 if let Err(error) =
-                                    process_session_command(&runtime, &mut session_value, &device_id, command)
+                                    process_session_command(
+                                        &runtime,
+                                        &mut session_value,
+                                        &device_id,
+                                        &auth_handler,
+                                        command,
+                                    )
                                         .await
                                 {
                                     if let Ok(mut guard) = session.lock().await {
@@ -1109,6 +1161,7 @@ impl EventSource for MqttDriver {
                         &mut session_value,
                         &device_id,
                         Some(&negotiated_connack),
+                        Some(&auth_handler),
                         Some(core::time::Duration::from_millis(MQTT_LISTENER_IDLE_POLL_MS)),
                     )
                     .await;

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -1,0 +1,443 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use ferredge_core::prelude::*;
+
+mod convert;
+#[cfg(feature = "std")]
+mod runtime;
+#[cfg(test)]
+mod tests;
+mod types;
+
+use types::{MqttPacketRequest, MqttResourceAttributes};
+
+#[cfg(feature = "std")]
+use runtime::{
+    build_connect_packet, handle_connection_events, mqtt_version_from_core,
+    normalize_broker_addr, read_from_session, send_packet_request, MqttClientSession,
+};
+
+pub use types::{
+    MqttCommandConversionError, MqttPublishRequest, MqttSubscriptionRequest, MqttWirePacket,
+};
+
+/// Current state of the MQTT background listener runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MqttListenerStatus {
+    /// Listener is not running and no failure is recorded.
+    Stopped,
+    /// Listener is actively polling the broker session.
+    Running,
+    /// Listener stopped after a runtime or sink failure.
+    Failed(String),
+}
+
+/// MQTT adapter scaffold backed by `mqtt_protocol_core` packet builders.
+#[derive(Clone)]
+pub struct MqttDriver {
+    /// Device metadata and broker configuration served by this driver.
+    pub dvc: Device<MqttResourceAttributes>,
+    /// Live MQTT client session for std-enabled runtime transport.
+    #[cfg(feature = "std")]
+    session: Arc<Mutex<Option<MqttClientSession>>>,
+    /// Background listener run flag.
+    #[cfg(feature = "std")]
+    listener_running: Arc<AtomicBool>,
+    /// Background listener thread handle.
+    #[cfg(feature = "std")]
+    listener_handle: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+    /// Last background listener failure, if any.
+    #[cfg(feature = "std")]
+    listener_error: Arc<Mutex<Option<String>>>,
+}
+
+impl core::fmt::Debug for MqttDriver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MqttDriver").field("dvc", &self.dvc).finish()
+    }
+}
+
+impl MqttDriver {
+    /// Creates a new MQTT driver from device metadata.
+    pub fn new(dvc: Device<MqttResourceAttributes>) -> Self {
+        Self {
+            dvc,
+            #[cfg(feature = "std")]
+            session: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "std")]
+            listener_running: Arc::new(AtomicBool::new(false)),
+            #[cfg(feature = "std")]
+            listener_handle: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "std")]
+            listener_error: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Establishes std transport session and MQTT handshake if not already connected.
+    #[cfg(feature = "std")]
+    pub fn connect(&self) -> Result<(), String> {
+        self.ensure_connected()
+    }
+
+    /// Reads one batch of inbound MQTT data and converts packets into routed messages.
+    #[cfg(feature = "std")]
+    pub fn poll(&self) -> Result<Vec<RoutedMessage>, String> {
+        self.ensure_connected()?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        let session = guard
+            .as_mut()
+            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+        read_from_session(session, &self.dvc.id, Some(std::time::Duration::from_millis(50)))
+    }
+
+    #[cfg(feature = "std")]
+    fn ensure_connected(&self) -> Result<(), String> {
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        if guard.is_some() {
+            return Ok(());
+        }
+
+        let config = match &self.dvc.endpoint {
+            DeviceEndpoint::Mqtt(config) => config,
+            _ => return Err("device endpoint is not MQTT".to_string()),
+        };
+
+        let stream = std::net::TcpStream::connect(normalize_broker_addr(&config.broker))
+            .map_err(|e| format!("failed to connect to MQTT broker: {e}"))?;
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_millis(1000)))
+            .map_err(|e| format!("failed to set MQTT read timeout: {e}"))?;
+        stream
+            .set_write_timeout(Some(std::time::Duration::from_millis(1000)))
+            .map_err(|e| format!("failed to set MQTT write timeout: {e}"))?;
+
+        let version = mqtt_version_from_core(config.preferred_protocol_version());
+        let mut connection =
+            mqtt_protocol_core::mqtt::Connection::<mqtt_protocol_core::mqtt::role::Client>::new(
+                version,
+            );
+        connection.set_auto_pub_response(true);
+
+        let connect_packet = build_connect_packet(config)?;
+        let mut session = MqttClientSession {
+            stream,
+            connection,
+            pending_command_ids: std::collections::HashMap::new(),
+        };
+        let events = session.connection.checked_send(connect_packet);
+        handle_connection_events(&mut session, &self.dvc.id, events)?;
+        let _ = read_from_session(
+            &mut session,
+            &self.dvc.id,
+            Some(std::time::Duration::from_millis(1000)),
+        )?;
+
+        *guard = Some(session);
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn stop_listener(&self) -> Result<(), String> {
+        self.listener_running.store(false, Ordering::SeqCst);
+        let mut handle_guard = self
+            .listener_handle
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
+        if let Some(handle) = handle_guard.take() {
+            if handle.join().is_err() {
+                let mut error_guard = self
+                    .listener_error
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT listener error".to_string())?;
+                if error_guard.is_none() {
+                    *error_guard = Some("MQTT listener thread panicked".to_string());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the last background listener error captured by the runtime, if any.
+    #[cfg(feature = "std")]
+    pub fn last_listener_error(&self) -> Result<Option<String>, String> {
+        self.listener_error
+            .lock()
+            .map(|error| error.clone())
+            .map_err(|_| "failed to lock MQTT listener error".to_string())
+    }
+
+    /// Clears any previously captured background listener error.
+    #[cfg(feature = "std")]
+    pub fn clear_listener_error(&self) -> Result<(), String> {
+        let mut guard = self
+            .listener_error
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener error".to_string())?;
+        *guard = None;
+        Ok(())
+    }
+
+    /// Returns high-level background listener status for this MQTT driver.
+    #[cfg(feature = "std")]
+    pub fn listener_status(&self) -> Result<MqttListenerStatus, String> {
+        if self.listener_running.load(Ordering::SeqCst) {
+            return Ok(MqttListenerStatus::Running);
+        }
+
+        match self.last_listener_error()? {
+            Some(error) => Ok(MqttListenerStatus::Failed(error)),
+            None => Ok(MqttListenerStatus::Stopped),
+        }
+    }
+}
+
+impl Lifecycle for MqttDriver {
+    type Error = String;
+
+    #[cfg(feature = "std")]
+    async fn start(&self) -> Result<(), Self::Error> {
+        self.connect()
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn start(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    async fn stop(&self) -> Result<(), Self::Error> {
+        self.stop_listener()?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        *guard = None;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn stop(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl PubSub for MqttDriver {
+    type PublishRequest = MqttPacketRequest;
+    type Subscription = MqttPacketRequest;
+    type Error = String;
+
+    #[cfg(feature = "std")]
+    async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
+        self.ensure_connected()?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        let session = guard
+            .as_mut()
+            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+
+        send_packet_request(session, &self.dvc.id, request)?;
+        let _ = read_from_session(
+            session,
+            &self.dvc.id,
+            Some(std::time::Duration::from_millis(250)),
+        )?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn publish(&self, _request: Self::PublishRequest) -> Result<(), Self::Error> {
+        Err("MQTT transport runtime not implemented yet".to_string())
+    }
+
+    #[cfg(feature = "std")]
+    async fn subscribe<S>(
+        &self,
+        subscription: Self::Subscription,
+        sink: S,
+    ) -> Result<(), Self::Error>
+    where
+        S: EventSink<Event = RoutedEvent> + Send,
+    {
+        self.ensure_connected()?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        let session = guard
+            .as_mut()
+            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+
+        send_packet_request(session, &self.dvc.id, subscription)?;
+        let messages = read_from_session(
+            session,
+            &self.dvc.id,
+            Some(std::time::Duration::from_millis(250)),
+        )?;
+        let mut sink = sink;
+        for message in messages {
+            if let RoutedMessage::Event(event) = message {
+                sink.handle(event)
+                    .map_err(|_| "failed to forward MQTT event to sink".to_string())?;
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn subscribe<S>(
+        &self,
+        _subscription: Self::Subscription,
+        _sink: S,
+    ) -> Result<(), Self::Error>
+    where
+        S: EventSink<Event = RoutedEvent> + Send,
+    {
+        Err("MQTT transport runtime not implemented yet".to_string())
+    }
+
+    #[cfg(feature = "std")]
+    async fn unsubscribe(&self, subscription: Self::Subscription) -> Result<(), Self::Error> {
+        self.ensure_connected()?;
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        let session = guard
+            .as_mut()
+            .ok_or_else(|| "MQTT session not initialized".to_string())?;
+
+        send_packet_request(session, &self.dvc.id, subscription)?;
+        let _ = read_from_session(
+            session,
+            &self.dvc.id,
+            Some(std::time::Duration::from_millis(250)),
+        )?;
+        Ok(())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn unsubscribe(&self, _subscription: Self::Subscription) -> Result<(), Self::Error> {
+        Err("MQTT transport runtime not implemented yet".to_string())
+    }
+}
+
+impl EventSource for MqttDriver {
+    type Event = RoutedEvent;
+    type Error = String;
+
+    #[cfg(feature = "std")]
+    async fn start_listening<S>(&self, sink: S) -> Result<(), Self::Error>
+    where
+        S: EventSink<Event = Self::Event> + Send + 'static,
+    {
+        self.ensure_connected()?;
+        if self.listener_running.swap(true, Ordering::SeqCst) {
+            return Err("MQTT listener already running".to_string());
+        }
+
+        let session = Arc::clone(&self.session);
+        let running = Arc::clone(&self.listener_running);
+        let listener_error = Arc::clone(&self.listener_error);
+        let device_id = self.dvc.id.clone();
+        self.clear_listener_error()?;
+        let handle = std::thread::spawn(move || {
+            let mut sink = sink;
+            while running.load(Ordering::SeqCst) {
+                let messages = {
+                    let mut guard = match session.lock() {
+                        Ok(guard) => guard,
+                        Err(_) => {
+                            if let Ok(mut error_guard) = listener_error.lock() {
+                                *error_guard =
+                                    Some("failed to lock MQTT session while listening".to_string());
+                            }
+                            break;
+                        }
+                    };
+                    let session = match guard.as_mut() {
+                        Some(session) => session,
+                        None => {
+                            if let Ok(mut error_guard) = listener_error.lock() {
+                                *error_guard =
+                                    Some("MQTT session missing while listener was running".to_string());
+                            }
+                            break;
+                        }
+                    };
+                    read_from_session(
+                        session,
+                        &device_id,
+                        Some(std::time::Duration::from_millis(250)),
+                    )
+                };
+
+                match messages {
+                    Ok(messages) => {
+                        for message in messages {
+                            if let RoutedMessage::Event(event) = message
+                                && sink.handle(event).is_err()
+                            {
+                                if let Ok(mut error_guard) = listener_error.lock() {
+                                    *error_guard =
+                                        Some("failed to forward MQTT event to sink".to_string());
+                                }
+                                running.store(false, Ordering::SeqCst);
+                                break;
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        if let Ok(mut error_guard) = listener_error.lock() {
+                            *error_guard = Some(error);
+                        }
+                        running.store(false, Ordering::SeqCst);
+                        break;
+                    }
+                }
+            }
+            running.store(false, Ordering::SeqCst);
+        });
+
+        let mut handle_guard = self
+            .listener_handle
+            .lock()
+            .map_err(|_| "failed to lock MQTT listener handle".to_string())?;
+        *handle_guard = Some(handle);
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    async fn stop_listening(&self) -> Result<(), Self::Error> {
+        self.stop_listener()
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn start_listening<S>(&self, _sink: S) -> Result<(), Self::Error>
+    where
+        S: EventSink<Event = Self::Event> + Send + 'static,
+    {
+        Err("MQTT event source not implemented for no_std environment".to_string())
+    }
+
+    #[cfg(not(feature = "std"))]
+    async fn stop_listening(&self) -> Result<(), Self::Error> {
+        Err("MQTT event source not implemented for no_std environment".to_string())
+    }
+}
+
+pub use types::MqttCommandRef;

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -1,3 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+//! MQTT protocol adapter for ferredge.
+//!
+//! With the default `std` feature, this crate provides a live TCP-backed MQTT client runtime,
+//! publish/subscribe operations, and background event listening.
+//!
+//! Without `std`, this crate still supports routed-command conversion into MQTT-native packet
+//! types through `TryFrom`, but transport runtime methods return explicit
+//! `requires the "std" feature` errors.
+
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
@@ -7,6 +17,12 @@ use std::sync::{
     mpsc,
     Arc, Mutex,
 };
+
+#[cfg(feature = "std")]
+use std::string::{String, ToString};
+
+#[cfg(not(feature = "std"))]
+use alloc::string::{String, ToString};
 
 use ferredge_core::prelude::*;
 
@@ -40,7 +56,11 @@ pub enum MqttListenerStatus {
     Failed(String),
 }
 
-/// MQTT adapter scaffold backed by `mqtt_protocol_core` packet builders.
+/// MQTT adapter backed by `mqtt_protocol_core` packet builders.
+///
+/// In `std` builds this type also owns the live TCP session and background listener runtime.
+/// In `no_std` builds it remains useful for packet conversion, but transport operations fail
+/// with explicit runtime-availability errors.
 #[derive(Clone)]
 pub struct MqttDriver {
     /// Device metadata and broker configuration served by this driver.
@@ -256,7 +276,7 @@ impl Lifecycle for MqttDriver {
 
     #[cfg(not(feature = "std"))]
     async fn start(&self) -> Result<(), Self::Error> {
-        Ok(())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
     #[cfg(feature = "std")]
@@ -273,7 +293,7 @@ impl Lifecycle for MqttDriver {
 
     #[cfg(not(feature = "std"))]
     async fn stop(&self) -> Result<(), Self::Error> {
-        Ok(())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }
 
@@ -304,7 +324,7 @@ impl PubSub for MqttDriver {
 
     #[cfg(not(feature = "std"))]
     async fn publish(&self, _request: Self::PublishRequest) -> Result<(), Self::Error> {
-        Err("MQTT transport runtime not implemented yet".to_string())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
     #[cfg(feature = "std")]
@@ -350,7 +370,7 @@ impl PubSub for MqttDriver {
     where
         S: EventSink<Event = RoutedEvent> + Send,
     {
-        Err("MQTT transport runtime not implemented yet".to_string())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
     #[cfg(feature = "std")]
@@ -375,7 +395,7 @@ impl PubSub for MqttDriver {
 
     #[cfg(not(feature = "std"))]
     async fn unsubscribe(&self, _subscription: Self::Subscription) -> Result<(), Self::Error> {
-        Err("MQTT transport runtime not implemented yet".to_string())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }
 
@@ -508,12 +528,12 @@ impl EventSource for MqttDriver {
     where
         S: EventSink<Event = Self::Event> + Send + 'static,
     {
-        Err("MQTT event source not implemented for no_std environment".to_string())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 
     #[cfg(not(feature = "std"))]
     async fn stop_listening(&self) -> Result<(), Self::Error> {
-        Err("MQTT event source not implemented for no_std environment".to_string())
+        Err("MQTT runtime requires the \"std\" feature".to_string())
     }
 }
 

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -52,13 +52,15 @@ use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
 
 #[cfg(test)]
 mod tests;
+#[cfg(all(test, feature = "mosquitto-tests"))]
+mod mosquitto_tests;
 
 use types::{MqttPacketRequest, MqttResourceAttributes};
 
 #[cfg(feature = "std")]
 use runtime::{
-    MqttClientSession, build_connect_packet, handle_connection_events, mqtt_version_from_core,
-    normalize_broker_addr, read_from_session, send_packet_request, disconnect_session,
+    MqttClientSession, build_connect_packet, mqtt_version_from_core, normalize_broker_addr,
+    read_from_session_async, send_packet_request_async, disconnect_session,
 };
 
 pub use types::{
@@ -138,39 +140,16 @@ impl MqttDriver {
         }
     }
 
-    /// Establishes std transport session and MQTT handshake if not already connected.
     #[cfg(feature = "std")]
-    pub fn connect(&self) -> Result<(), String> {
-        self.ensure_connected()
-    }
-
-    /// Reads one batch of inbound MQTT data and converts packets into routed messages.
-    #[cfg(feature = "std")]
-    pub fn poll(&self) -> Result<Vec<RoutedMessage>, String> {
-        self.ensure_connected()?;
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        let session = guard
-            .as_mut()
-            .ok_or_else(|| "MQTT session not initialized".to_string())?;
-        read_from_session(
-            self.runtime.as_ref(),
-            session,
-            &self.dvc.id,
-            Some(std::time::Duration::from_millis(50)),
-        )
-    }
-
-    #[cfg(feature = "std")]
-    fn ensure_connected(&self) -> Result<(), String> {
-        let mut guard = self
-            .session
-            .lock()
-            .map_err(|_| "failed to lock MQTT session".to_string())?;
-        if guard.is_some() {
-            return Ok(());
+    async fn ensure_connected_async(&self) -> Result<(), String> {
+        {
+            let guard = self
+                .session
+                .lock()
+                .map_err(|_| "failed to lock MQTT session".to_string())?;
+            if guard.is_some() {
+                return Ok(());
+            }
         }
 
         let config = match &self.dvc.endpoint {
@@ -178,10 +157,10 @@ impl MqttDriver {
             _ => return Err("device endpoint is not MQTT".to_string()),
         };
 
-        let mut stream = self.runtime.block_on(
-            self.net
-                .connect(normalize_broker_addr(&config.broker).as_str()),
-        )
+        let mut stream = self
+            .net
+            .connect(normalize_broker_addr(&config.broker).as_str())
+            .await
             .map_err(|e| format!("failed to connect to MQTT broker: {e:?}"))?;
         stream
             .set_read_timeout(Some(std::time::Duration::from_millis(1000)))
@@ -208,15 +187,21 @@ impl MqttDriver {
             pending_reply_routes: std::collections::HashMap::new(),
         };
         let events = session.connection.checked_send(connect_packet);
-        handle_connection_events(self.runtime.as_ref(), &mut session, &self.dvc.id, events)?;
-        let _ = read_from_session(
-            self.runtime.as_ref(),
+        runtime::handle_connection_events_async(&mut session, &self.dvc.id, events).await?;
+        let _ = read_from_session_async(
             &mut session,
             &self.dvc.id,
             Some(std::time::Duration::from_millis(1000)),
-        )?;
+        )
+        .await?;
 
-        *guard = Some(session);
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        if guard.is_none() {
+            *guard = Some(session);
+        }
         Ok(())
     }
 
@@ -322,17 +307,25 @@ impl MqttDriver {
         subscribers.retain(|subscriber| subscriber.send(status.clone()).is_ok());
         Ok(())
     }
+    #[cfg(feature = "std")]
+    fn take_session(&self) -> Result<MqttClientSession, String> {
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        guard
+            .take()
+            .ok_or_else(|| "MQTT session not initialized".to_string())
+    }
 
     #[cfg(feature = "std")]
-    fn reconnect_session(&self) -> Result<(), String> {
-        {
-            let mut guard = self
-                .session
-                .lock()
-                .map_err(|_| "failed to lock MQTT session".to_string())?;
-            *guard = None;
-        }
-        self.ensure_connected()
+    fn restore_session(&self, session: MqttClientSession) -> Result<(), String> {
+        let mut guard = self
+            .session
+            .lock()
+            .map_err(|_| "failed to lock MQTT session".to_string())?;
+        *guard = Some(session);
+        Ok(())
     }
 }
 
@@ -352,7 +345,7 @@ impl Lifecycle for MqttDriver {
     async fn start(&self) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            return self.connect();
+            return self.ensure_connected_async().await;
         }
 
         #[cfg(not(feature = "std"))]
@@ -363,14 +356,16 @@ impl Lifecycle for MqttDriver {
         #[cfg(feature = "std")]
         {
             self.stop_listener()?;
-            let mut guard = self
-                .session
-                .lock()
-                .map_err(|_| "failed to lock MQTT session".to_string())?;
-            if let Some(session) = guard.as_mut() {
-                let _ = self.runtime.block_on(disconnect_session(session));
+            let maybe_session = {
+                let mut guard = self
+                    .session
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT session".to_string())?;
+                guard.take()
+            };
+            if let Some(mut session) = maybe_session {
+                let _ = disconnect_session(&mut session).await;
             }
-            *guard = None;
             self.broadcast_listener_status(self.listener_status()?)?;
             return Ok(());
         }
@@ -388,22 +383,21 @@ impl PubSub for MqttDriver {
     async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected()?;
-            let mut guard = self
-                .session
-                .lock()
-                .map_err(|_| "failed to lock MQTT session".to_string())?;
-            let session = guard
-                .as_mut()
-                .ok_or_else(|| "MQTT session not initialized".to_string())?;
-
-            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, request)?;
-            let _ = read_from_session(
-                self.runtime.as_ref(),
-                session,
-                &self.dvc.id,
-                Some(std::time::Duration::from_millis(250)),
-            )?;
+            self.ensure_connected_async().await?;
+            let mut session = self.take_session()?;
+            let result = async {
+                send_packet_request_async(&mut session, &self.dvc.id, request).await?;
+                let _ = read_from_session_async(
+                    &mut session,
+                    &self.dvc.id,
+                    Some(std::time::Duration::from_millis(250)),
+                )
+                .await?;
+                Ok::<(), String>(())
+            }
+            .await;
+            self.restore_session(session)?;
+            result?;
             return Ok(());
         }
 
@@ -421,22 +415,20 @@ impl PubSub for MqttDriver {
     {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected()?;
-            let mut guard = self
-                .session
-                .lock()
-                .map_err(|_| "failed to lock MQTT session".to_string())?;
-            let session = guard
-                .as_mut()
-                .ok_or_else(|| "MQTT session not initialized".to_string())?;
-
-            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, subscription)?;
-            let messages = read_from_session(
-                self.runtime.as_ref(),
-                session,
-                &self.dvc.id,
-                Some(std::time::Duration::from_millis(250)),
-            )?;
+            self.ensure_connected_async().await?;
+            let mut session = self.take_session()?;
+            let result = async {
+                send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
+                read_from_session_async(
+                    &mut session,
+                    &self.dvc.id,
+                    Some(std::time::Duration::from_millis(250)),
+                )
+                .await
+            }
+            .await;
+            self.restore_session(session)?;
+            let messages = result?;
             let mut sink = sink;
             for message in messages {
                 if let RoutedMessage::Event(event) = message {
@@ -454,22 +446,21 @@ impl PubSub for MqttDriver {
     async fn unsubscribe(&self, subscription: Self::Subscription) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected()?;
-            let mut guard = self
-                .session
-                .lock()
-                .map_err(|_| "failed to lock MQTT session".to_string())?;
-            let session = guard
-                .as_mut()
-                .ok_or_else(|| "MQTT session not initialized".to_string())?;
-
-            send_packet_request(self.runtime.as_ref(), session, &self.dvc.id, subscription)?;
-            let _ = read_from_session(
-                self.runtime.as_ref(),
-                session,
-                &self.dvc.id,
-                Some(std::time::Duration::from_millis(250)),
-            )?;
+            self.ensure_connected_async().await?;
+            let mut session = self.take_session()?;
+            let result = async {
+                send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
+                let _ = read_from_session_async(
+                    &mut session,
+                    &self.dvc.id,
+                    Some(std::time::Duration::from_millis(250)),
+                )
+                .await?;
+                Ok::<(), String>(())
+            }
+            .await;
+            self.restore_session(session)?;
+            result?;
             return Ok(());
         }
 
@@ -488,7 +479,7 @@ impl EventSource for MqttDriver {
     {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected()?;
+            self.ensure_connected_async().await?;
             if self.listener_running.swap(true, Ordering::SeqCst) {
                 return Err("MQTT listener already running".to_string());
             }
@@ -506,7 +497,7 @@ impl EventSource for MqttDriver {
                 let mut sink = sink;
 
                 while running.load(Ordering::SeqCst) {
-                    let messages = {
+                    let mut session_value = {
                         let mut guard = match session.lock() {
                             Ok(guard) => guard,
                             Err(_) => {
@@ -524,7 +515,7 @@ impl EventSource for MqttDriver {
                                 break;
                             }
                         };
-                        let session = match guard.as_mut() {
+                        match guard.take() {
                             Some(session) => session,
                             None => {
                                 if let Ok(mut error_guard) = listener_error.lock() {
@@ -541,14 +532,17 @@ impl EventSource for MqttDriver {
                                 );
                                 break;
                             }
-                        };
-                        read_from_session(
-                            runtime.as_ref(),
-                            session,
-                            &device_id,
-                            Some(std::time::Duration::from_millis(250)),
-                        )
+                        }
                     };
+                    let messages = read_from_session_async(
+                        &mut session_value,
+                        &device_id,
+                        Some(std::time::Duration::from_millis(250)),
+                    )
+                    .await;
+                    if let Ok(mut guard) = session.lock() {
+                        *guard = Some(session_value);
+                    }
 
                     match messages {
                         Ok(messages) => {
@@ -573,7 +567,9 @@ impl EventSource for MqttDriver {
                             }
                         }
                         Err(error) => {
-                            if running.load(Ordering::SeqCst) && driver.reconnect_session().is_ok() {
+                            if running.load(Ordering::SeqCst)
+                                && driver.ensure_connected_async().await.is_ok()
+                            {
                                 if let Ok(mut error_guard) = listener_error.lock() {
                                     *error_guard = None;
                                 }

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -162,6 +162,7 @@ impl MqttDriver {
             stream,
             connection,
             pending_command_ids: std::collections::HashMap::new(),
+            pending_reply_routes: std::collections::HashMap::new(),
         };
         let events = session.connection.checked_send(connect_packet);
         handle_connection_events(&mut session, &self.dvc.id, events)?;

--- a/crates/ferredge-proto-mqtt/src/lib.rs
+++ b/crates/ferredge-proto-mqtt/src/lib.rs
@@ -50,17 +50,17 @@ mod runtime_stack {
 #[cfg(feature = "std")]
 use runtime_stack::{RuntimeTask, StackNet, StackRuntime};
 
-#[cfg(test)]
-mod tests;
 #[cfg(all(test, feature = "mosquitto-tests"))]
 mod mosquitto_tests;
+#[cfg(test)]
+mod tests;
 
 use types::{MqttPacketRequest, MqttResourceAttributes};
 
 #[cfg(feature = "std")]
 use runtime::{
-    MqttClientSession, build_connect_packet, mqtt_version_from_core, normalize_broker_addr,
-    read_from_session_async, send_packet_request_async, disconnect_session,
+    MqttClientSession, build_connect_packet, disconnect_session, mqtt_version_from_core,
+    normalize_broker_addr, read_from_session_async, send_packet_request_async,
 };
 
 pub use types::{
@@ -108,6 +108,12 @@ pub struct MqttDriver {
     /// Selected network adapter used for outbound sockets.
     #[cfg(feature = "std")]
     net: StackNet,
+    /// Desired subscription state to replay after reconnect.
+    #[cfg(feature = "std")]
+    desired_subscriptions: Arc<Mutex<Map<String, MqttPacketRequest>>>,
+    /// Queued outbound requests waiting for broker recovery.
+    #[cfg(feature = "std")]
+    recovery_queue: Arc<Mutex<VecDeque<MqttPacketRequest>>>,
 }
 
 impl core::fmt::Debug for MqttDriver {
@@ -137,6 +143,10 @@ impl MqttDriver {
             runtime: Arc::new(StackRuntime::default()),
             #[cfg(feature = "std")]
             net: StackNet::default(),
+            #[cfg(feature = "std")]
+            desired_subscriptions: Arc::new(Mutex::new(Map::new())),
+            #[cfg(feature = "std")]
+            recovery_queue: Arc::new(Mutex::new(VecDeque::new())),
         }
     }
 
@@ -211,6 +221,120 @@ impl MqttDriver {
             DeviceEndpoint::Mqtt(config) => Ok(config.reconnect.clone()),
             _ => Err("device endpoint is not MQTT".to_string()),
         }
+    }
+
+    #[cfg(feature = "std")]
+    fn request_topic_key(request: &MqttPacketRequest) -> Option<String> {
+        match &request.packet {
+            MqttWirePacket::V5Subscribe(packet) => packet
+                .entries()
+                .first()
+                .map(|entry| entry.topic_filter().to_string()),
+            MqttWirePacket::V3Subscribe(packet) => packet
+                .entries()
+                .first()
+                .map(|entry| entry.topic_filter().to_string()),
+            MqttWirePacket::V5Unsubscribe(packet) => packet
+                .entries()
+                .first()
+                .map(|entry| entry.as_str().to_string()),
+            MqttWirePacket::V3Unsubscribe(packet) => packet
+                .entries()
+                .first()
+                .map(|entry| entry.as_str().to_string()),
+            _ => None,
+        }
+    }
+
+    #[cfg(feature = "std")]
+    fn track_subscription_intent(&self, request: &MqttPacketRequest) -> Result<(), String> {
+        let Some(topic) = Self::request_topic_key(request) else {
+            return Ok(());
+        };
+        let mut desired = self
+            .desired_subscriptions
+            .lock()
+            .map_err(|_| "failed to lock MQTT desired subscriptions".to_string())?;
+        match request.packet {
+            MqttWirePacket::V5Subscribe(_) | MqttWirePacket::V3Subscribe(_) => {
+                desired.insert(topic, request.clone());
+            }
+            MqttWirePacket::V5Unsubscribe(_) | MqttWirePacket::V3Unsubscribe(_) => {
+                desired.remove(&topic);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn enqueue_recovery_request(&self, request: MqttPacketRequest) -> Result<(), String> {
+        let reconnect = self.reconnect_config()?;
+        if !reconnect.queue_requests_while_disconnected {
+            return Err("MQTT recovery queue is disabled".to_string());
+        }
+
+        let mut queue = self
+            .recovery_queue
+            .lock()
+            .map_err(|_| "failed to lock MQTT recovery queue".to_string())?;
+        if queue.len() >= reconnect.max_queued_requests as usize {
+            queue.pop_front();
+        }
+        queue.push_back(request);
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    async fn replay_recovery_state_async(&self) -> Result<(), String> {
+        let reconnect = self.reconnect_config()?;
+        let mut session = self.take_session_wait_async().await?;
+        let result = async {
+            if reconnect.replay_subscriptions {
+                let desired = self
+                    .desired_subscriptions
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT desired subscriptions".to_string())?
+                    .values()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                for request in desired {
+                    send_packet_request_async(&mut session, &self.dvc.id, request).await?;
+                    let _ = read_from_session_async(
+                        &mut session,
+                        &self.dvc.id,
+                        Some(std::time::Duration::from_millis(250)),
+                    )
+                    .await?;
+                }
+            }
+
+            let queued = {
+                let mut queue = self
+                    .recovery_queue
+                    .lock()
+                    .map_err(|_| "failed to lock MQTT recovery queue".to_string())?;
+                queue.drain(..).collect::<Vec<_>>()
+            };
+            for request in queued {
+                send_packet_request_async(&mut session, &self.dvc.id, request).await?;
+                let _ = read_from_session_async(
+                    &mut session,
+                    &self.dvc.id,
+                    Some(std::time::Duration::from_millis(250)),
+                )
+                .await?;
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+
+        if result.is_ok() {
+            self.restore_session(session)?;
+        } else {
+            self.clear_session()?;
+        }
+        result
     }
 
     #[cfg(feature = "std")]
@@ -413,10 +537,17 @@ impl PubSub for MqttDriver {
     async fn publish(&self, request: Self::PublishRequest) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected_async().await?;
+            if let Err(error) = self.ensure_connected_async().await {
+                if self.listener_running.load(Ordering::SeqCst)
+                    && self.enqueue_recovery_request(request.clone()).is_ok()
+                {
+                    return Ok(());
+                }
+                return Err(error);
+            }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, request).await?;
+                send_packet_request_async(&mut session, &self.dvc.id, request.clone()).await?;
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
@@ -430,6 +561,10 @@ impl PubSub for MqttDriver {
                 self.restore_session(session)?;
             } else {
                 self.clear_session()?;
+                if self.listener_running.load(Ordering::SeqCst) {
+                    let _ = self.enqueue_recovery_request(request);
+                    return Ok(());
+                }
             }
             result?;
             return Ok(());
@@ -449,10 +584,18 @@ impl PubSub for MqttDriver {
     {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected_async().await?;
+            self.track_subscription_intent(&subscription)?;
+            if let Err(error) = self.ensure_connected_async().await {
+                if self.listener_running.load(Ordering::SeqCst)
+                    && self.enqueue_recovery_request(subscription.clone()).is_ok()
+                {
+                    return Ok(());
+                }
+                return Err(error);
+            }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
+                send_packet_request_async(&mut session, &self.dvc.id, subscription.clone()).await?;
                 read_from_session_async(
                     &mut session,
                     &self.dvc.id,
@@ -465,6 +608,10 @@ impl PubSub for MqttDriver {
                 self.restore_session(session)?;
             } else {
                 self.clear_session()?;
+                if self.listener_running.load(Ordering::SeqCst) {
+                    let _ = self.enqueue_recovery_request(subscription);
+                    return Ok(());
+                }
             }
             let messages = result?;
             let mut sink = sink;
@@ -484,10 +631,18 @@ impl PubSub for MqttDriver {
     async fn unsubscribe(&self, subscription: Self::Subscription) -> Result<(), Self::Error> {
         #[cfg(feature = "std")]
         {
-            self.ensure_connected_async().await?;
+            self.track_subscription_intent(&subscription)?;
+            if let Err(error) = self.ensure_connected_async().await {
+                if self.listener_running.load(Ordering::SeqCst)
+                    && self.enqueue_recovery_request(subscription.clone()).is_ok()
+                {
+                    return Ok(());
+                }
+                return Err(error);
+            }
             let mut session = self.take_session_wait_async().await?;
             let result = async {
-                send_packet_request_async(&mut session, &self.dvc.id, subscription).await?;
+                send_packet_request_async(&mut session, &self.dvc.id, subscription.clone()).await?;
                 let _ = read_from_session_async(
                     &mut session,
                     &self.dvc.id,
@@ -501,6 +656,10 @@ impl PubSub for MqttDriver {
                 self.restore_session(session)?;
             } else {
                 self.clear_session()?;
+                if self.listener_running.load(Ordering::SeqCst) {
+                    let _ = self.enqueue_recovery_request(subscription);
+                    return Ok(());
+                }
             }
             result?;
             return Ok(());
@@ -622,6 +781,12 @@ impl EventSource for MqttDriver {
 
                                 match driver.ensure_connected_async().await {
                                     Ok(()) => {
+                                        if let Err(recovery_error) =
+                                            driver.replay_recovery_state_async().await
+                                        {
+                                            error = recovery_error;
+                                            continue;
+                                        }
                                         reconnect_attempt = 0;
                                         if let Ok(mut error_guard) = listener_error.lock() {
                                             *error_guard = None;

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -7,11 +7,12 @@ use std::{
 };
 
 use ferredge_core::prelude::{
-    Address, BrokerAddress, BrokerBackoffStrategy, BrokerMessageOptions, BrokerReconnectConfig,
-    BrokerSubscriptionOptions, BrokerChannelKind, Command, Correlation, DeliveryGuarantee, Device,
+    Address, BrokerAddress, BrokerBackoffStrategy, BrokerChannelKind, BrokerMessageOptions,
+    BrokerMessageProtocolOptions, BrokerReconnectConfig, BrokerSubscriptionOptions,
+    BrokerSubscriptionProtocolOptions, Command, Correlation, DeliveryGuarantee, Device,
     DeviceEndpoint, DeviceStatus, EventSink, EventSource, Intent, Lifecycle, Map,
-    MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion, PubSub, RoutedEvent,
-    TransportMeta,
+    MqttConnectProperties, MqttEndpointConfig, MqttMessageOptions, MqttPayloadFormat,
+    MqttProtocolVersion, MqttSubscriptionOptions, PubSub, RoutedEvent, TransportMeta,
 };
 
 use crate::{
@@ -86,6 +87,7 @@ fn make_driver_with_config(
             session_expiry_secs,
             topic_prefix: None,
             connect_properties: MqttConnectProperties::default(),
+            will: None,
             reconnect,
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),
@@ -527,13 +529,17 @@ fn mosquitto_v5_complex_property_roundtrip() {
         br#"{"ok":true}"#,
         BrokerMessageOptions {
             delivery: Some(DeliveryGuarantee::BestEffort),
-            headers: vec![
-                ("content-type".to_string(), "application/json".to_string()),
-                ("x-trace".to_string(), "trace-123".to_string()),
-                ("x-origin".to_string(), "ferredge".to_string()),
-            ],
             reply_to: Some("ferredge/it/reply".to_string()),
             correlation_id: Some("corr-v5-123".to_string()),
+            protocol: Some(BrokerMessageProtocolOptions::Mqtt(MqttMessageOptions {
+                content_type: Some("application/json".to_string()),
+                user_properties: vec![
+                    ("x-trace".to_string(), "trace-123".to_string()),
+                    ("x-origin".to_string(), "ferredge".to_string()),
+                ],
+                ..MqttMessageOptions::default()
+            })),
+            ..BrokerMessageOptions::default()
         },
     )))
     .expect("publisher should publish");
@@ -569,6 +575,276 @@ fn mosquitto_v5_complex_property_roundtrip() {
 
     block_on(publisher.stop()).expect("publisher should stop cleanly");
     block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+fn mosquitto_retained_publish_roundtrip_preserves_meta() {
+    let broker = MosquittoGuard::start();
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        "mqtt-retain-publisher",
+        "ferredge-mosquitto-retain-publisher",
+    );
+    let subscriber = make_named_driver(
+        broker.broker_url(),
+        "mqtt-retain-subscriber",
+        "ferredge-mosquitto-retain-subscriber",
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let topic = "ferredge/it/retain";
+    let payload = br#"{"retained":true}"#;
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "pub-retain-1",
+        topic,
+        payload,
+        BrokerMessageOptions {
+            protocol: Some(BrokerMessageProtocolOptions::Mqtt(MqttMessageOptions {
+                retain: true,
+                payload_format: Some(MqttPayloadFormat::Utf8),
+                content_type: Some("application/json".to_string()),
+                message_expiry_interval_secs: Some(30),
+                ..MqttMessageOptions::default()
+            })),
+            ..BrokerMessageOptions::default()
+        },
+    )))
+    .expect("publisher should publish retained payload");
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+
+    block_on(subscriber.start()).expect("subscriber should connect");
+    block_on(subscriber.subscribe(
+        subscribe_packet(&subscriber, "sub-retain-1", topic),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("subscriber should subscribe");
+    block_on(subscriber.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("subscriber listener should start");
+
+    let event = wait_for_event_payload(&events, payload);
+    assert_eq!(event.address, Address::Channel(topic.to_string()));
+    match event.transport {
+        Some(TransportMeta::Mqtt(meta)) => {
+            assert!(meta.retain, "retained publish should stay marked retained");
+            assert_eq!(meta.content_type, Some("application/json".to_string()));
+            assert_eq!(meta.payload_format, Some("1".to_string()));
+            assert_eq!(meta.message_expiry_interval_secs, Some(30));
+        }
+        other => panic!("expected MQTT transport metadata, got {other:?}"),
+    }
+
+    let clear_status = ProcessCommand::new("mosquitto_pub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            topic,
+            "-n",
+            "-r",
+        ])
+        .status()
+        .expect("mosquitto_pub should clear retained message");
+    assert!(clear_status.success());
+
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_v5_subscription_identifier_and_no_local_work() {
+    let broker = MosquittoGuard::start();
+    let driver = make_named_driver(
+        broker.broker_url(),
+        "mqtt-subopts-device",
+        "ferredge-mosquitto-subopts",
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let topic = "ferredge/it/subopts";
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.subscribe(
+        MqttPacketRequest::try_from(MqttCommandRef {
+            device: &driver.dvc,
+            command: &Command {
+                id: "subopts-sub".to_string(),
+                source_device_id: None,
+                target_device_id: driver.dvc.id.clone(),
+                intent: Intent::Subscribe {
+                    channel: BrokerAddress {
+                        name: topic.to_string(),
+                        kind: Some(BrokerChannelKind::Topic),
+                    },
+                    options: BrokerSubscriptionOptions {
+                        delivery: Some(DeliveryGuarantee::AtLeastOnce),
+                        protocol: Some(BrokerSubscriptionProtocolOptions::Mqtt(
+                            MqttSubscriptionOptions {
+                                no_local: true,
+                                subscription_identifier: Some(41),
+                                ..MqttSubscriptionOptions::default()
+                            },
+                        )),
+                        ..BrokerSubscriptionOptions::default()
+                    },
+                },
+                correlation: None,
+            },
+        })
+        .expect("subscribe packet should build"),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("driver should subscribe");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("driver listener should start");
+
+    block_on(driver.publish(publish_packet(
+        &driver,
+        "subopts-pub-self",
+        topic,
+        b"self-should-not-loop",
+        BrokerMessageOptions::default(),
+    )))
+    .expect("driver should publish to same topic");
+    thread::sleep(Duration::from_millis(MOSQUITTO_UNSUBSCRIBE_SETTLE_MS));
+    assert!(
+        events.lock().expect("events lock").is_empty(),
+        "no_local subscription should suppress own publish"
+    );
+
+    let pub_status = ProcessCommand::new("mosquitto_pub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            topic,
+            "-m",
+            "remote-should-arrive",
+        ])
+        .status()
+        .expect("mosquitto_pub should publish remote message");
+    assert!(pub_status.success());
+
+    let event = wait_for_event_payload(&events, b"remote-should-arrive");
+    match event.transport {
+        Some(TransportMeta::Mqtt(meta)) => {
+            assert_eq!(meta.subscription_identifiers, vec![41]);
+        }
+        other => panic!("expected MQTT transport metadata, got {other:?}"),
+    }
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_shared_subscriptions_load_balance() {
+    let broker = MosquittoGuard::start();
+    let subscriber_a = make_named_driver(
+        broker.broker_url(),
+        "mqtt-shared-subscriber-a",
+        "ferredge-mosquitto-shared-a",
+    );
+    let subscriber_b = make_named_driver(
+        broker.broker_url(),
+        "mqtt-shared-subscriber-b",
+        "ferredge-mosquitto-shared-b",
+    );
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        "mqtt-shared-publisher",
+        "ferredge-mosquitto-shared-publisher",
+    );
+    let events_a = Arc::new(Mutex::new(Vec::new()));
+    let events_b = Arc::new(Mutex::new(Vec::new()));
+    let topic = "ferredge/it/shared";
+
+    for (driver, events, sub_id) in [
+        (&subscriber_a, Arc::clone(&events_a), "shared-sub-a"),
+        (&subscriber_b, Arc::clone(&events_b), "shared-sub-b"),
+    ] {
+        block_on(driver.start()).expect("subscriber should connect");
+        block_on(driver.subscribe(
+            MqttPacketRequest::try_from(MqttCommandRef {
+                device: &driver.dvc,
+                command: &Command {
+                    id: sub_id.to_string(),
+                    source_device_id: None,
+                    target_device_id: driver.dvc.id.clone(),
+                    intent: Intent::Subscribe {
+                        channel: BrokerAddress {
+                            name: topic.to_string(),
+                            kind: Some(BrokerChannelKind::Topic),
+                        },
+                        options: BrokerSubscriptionOptions {
+                            shared_group: Some("workers".to_string()),
+                            ..BrokerSubscriptionOptions::default()
+                        },
+                    },
+                    correlation: None,
+                },
+            })
+            .expect("shared subscribe should build"),
+            RecordingSink {
+                events: Arc::clone(&events),
+            },
+        ))
+        .expect("subscriber should subscribe shared topic");
+        block_on(driver.start_listening(RecordingSink {
+            events: Arc::clone(&events),
+        }))
+        .expect("subscriber listener should start");
+    }
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "shared-pub-1",
+        topic,
+        b"shared-only-once",
+        BrokerMessageOptions::default(),
+    )))
+    .expect("publisher should publish shared test message");
+
+    let deadline = Instant::now() + Duration::from_secs(MOSQUITTO_EVENT_WAIT_TIMEOUT_SECS);
+    loop {
+        let count = events_a.lock().expect("events_a lock").len()
+            + events_b.lock().expect("events_b lock").len();
+        if count == 1 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "shared subscription should deliver to exactly one subscriber"
+        );
+        thread::sleep(Duration::from_millis(MOSQUITTO_POLL_INTERVAL_MS));
+    }
+
+    assert_eq!(
+        events_a.lock().expect("events_a lock").len()
+            + events_b.lock().expect("events_b lock").len(),
+        1
+    );
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+    block_on(subscriber_a.stop()).expect("subscriber A should stop cleanly");
+    block_on(subscriber_b.stop()).expect("subscriber B should stop cleanly");
 }
 
 #[test]

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -7,10 +7,10 @@ use std::{
 };
 
 use ferredge_core::prelude::{
-    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions,
-    Command, Correlation, DeliveryGuarantee, Device, DeviceEndpoint, DeviceStatus, EventSink,
-    EventSource, Intent, Lifecycle, Map, MqttEndpointConfig, MqttProtocolVersion, PubSub,
-    RoutedEvent, TransportMeta,
+    Address, BrokerAddress, BrokerBackoffStrategy, BrokerMessageOptions, BrokerReconnectConfig,
+    BrokerSubscriptionOptions, BrokerChannelKind, Command, Correlation, DeliveryGuarantee, Device,
+    DeviceEndpoint, DeviceStatus, EventSink, EventSource, Intent, Lifecycle, Map,
+    MqttEndpointConfig, MqttProtocolVersion, PubSub, RoutedEvent, TransportMeta,
 };
 
 use crate::{
@@ -30,6 +30,36 @@ fn make_driver_with_client_id_and_keepalive(
     client_id: String,
     keepalive_secs: Option<u16>,
 ) -> MqttDriver {
+    make_driver_with_config(
+        broker,
+        device_id,
+        client_id,
+        keepalive_secs,
+        BrokerReconnectConfig {
+            enabled: true,
+            initial_delay_ms: 100,
+            max_delay_ms: 1_000,
+            strategy: BrokerBackoffStrategy::Exponential,
+            multiplier: 2,
+            max_attempts: None,
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 64,
+        },
+        true,
+        None,
+    )
+}
+
+fn make_driver_with_config(
+    broker: String,
+    device_id: String,
+    client_id: String,
+    keepalive_secs: Option<u16>,
+    reconnect: BrokerReconnectConfig,
+    clean_start: bool,
+    session_expiry_secs: Option<u32>,
+) -> MqttDriver {
     MqttDriver::new(Device {
         id: device_id,
         name: "MQTT Mosquitto Device".to_string(),
@@ -40,9 +70,10 @@ fn make_driver_with_client_id_and_keepalive(
             auth: None,
             tls: None,
             keepalive_secs,
-            clean_start: true,
-            session_expiry_secs: None,
+            clean_start,
+            session_expiry_secs,
             topic_prefix: None,
+            reconnect,
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),
         metadata: None,
@@ -70,30 +101,43 @@ fn reserve_free_port() -> u16 {
 }
 
 struct MosquittoGuard {
-    child: Child,
+    child: Option<Child>,
     port: u16,
 }
 
 impl MosquittoGuard {
     fn start() -> Self {
         let port = reserve_free_port();
+        let mut guard = Self { child: None, port };
+        guard.start_broker();
+        guard
+    }
+
+    fn start_broker(&mut self) {
+        assert!(self.child.is_none(), "mosquitto broker already running");
         let child = ProcessCommand::new("mosquitto")
-            .args(["-p", &port.to_string(), "-v"])
+            .args(["-p", &self.port.to_string(), "-v"])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .expect("mosquitto should spawn");
+        self.child = Some(child);
 
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            if TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
                 break;
             }
             assert!(Instant::now() < deadline, "mosquitto should start before timeout");
             thread::sleep(Duration::from_millis(25));
         }
+    }
 
-        Self { child, port }
+    fn stop_broker(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
 
     fn host(&self) -> String {
@@ -111,8 +155,7 @@ impl MosquittoGuard {
 
 impl Drop for MosquittoGuard {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        self.stop_broker();
     }
 }
 
@@ -524,4 +567,235 @@ fn mosquitto_keepalive_client_flow_thirty_five_seconds() {
     );
 
     block_on(driver.stop()).expect("driver should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_listener_reconnects_after_broker_restart_for_publish() {
+    let mut broker = MosquittoGuard::start();
+    let driver = make_driver_with_config(
+        broker.broker_url(),
+        "mqtt-mosquitto-reconnect-device".to_string(),
+        "ferredge-mosquitto-reconnect".to_string(),
+        Some(2),
+        BrokerReconnectConfig {
+            enabled: true,
+            initial_delay_ms: 100,
+            max_delay_ms: 500,
+            strategy: BrokerBackoffStrategy::Exponential,
+            multiplier: 2,
+            max_attempts: None,
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 64,
+        },
+        true,
+        None,
+    );
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::new(Mutex::new(Vec::new())),
+    }))
+    .expect("listener should start");
+
+    broker.stop_broker();
+    thread::sleep(Duration::from_millis(400));
+    broker.start_broker();
+
+    let sub_child = ProcessCommand::new("mosquitto_sub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/reconnect/out",
+            "-C",
+            "1",
+            "-W",
+            "10",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mosquitto_sub should spawn");
+
+    thread::sleep(Duration::from_millis(1200));
+
+    block_on(driver.publish(publish_packet(
+        &driver,
+        "pub-reconnect-1",
+        "ferredge/it/reconnect/out",
+        b"reconnected-outbound-ok",
+        BrokerMessageOptions::default(),
+    )))
+    .expect("driver should publish after reconnect");
+
+    let output = sub_child
+        .wait_with_output()
+        .expect("mosquitto_sub should finish after reconnect");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "reconnected-outbound-ok"
+    );
+    assert_eq!(
+        driver.listener_status().expect("listener status should be readable"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_listener_fails_after_reconnect_attempt_budget_exhausted() {
+    let mut broker = MosquittoGuard::start();
+    let driver = make_driver_with_config(
+        broker.broker_url(),
+        "mqtt-mosquitto-reconnect-fail-device".to_string(),
+        "ferredge-mosquitto-reconnect-fail".to_string(),
+        Some(2),
+        BrokerReconnectConfig {
+            enabled: true,
+            initial_delay_ms: 100,
+            max_delay_ms: 100,
+            strategy: BrokerBackoffStrategy::Fixed,
+            multiplier: 1,
+            max_attempts: Some(2),
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 64,
+        },
+        true,
+        None,
+    );
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::new(Mutex::new(Vec::new())),
+    }))
+    .expect("listener should start");
+
+    broker.stop_broker();
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let status = driver
+            .listener_status()
+            .expect("listener status should be readable");
+        if matches!(status, MqttListenerStatus::Failed(_)) {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "listener should fail after reconnect attempts are exhausted"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    match driver
+        .listener_status()
+        .expect("listener status should be readable")
+    {
+        MqttListenerStatus::Failed(error) => {
+            assert!(!error.is_empty(), "failed listener should retain reconnect error");
+        }
+        other => panic!("expected failed listener status, got {other:?}"),
+    }
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_replays_subscriptions_and_queued_publish_after_restart() {
+    let mut broker = MosquittoGuard::start();
+    let reconnect = BrokerReconnectConfig {
+        enabled: true,
+        initial_delay_ms: 100,
+        max_delay_ms: 500,
+        strategy: BrokerBackoffStrategy::Exponential,
+        multiplier: 2,
+        max_attempts: None,
+        replay_subscriptions: true,
+        queue_requests_while_disconnected: true,
+        max_queued_requests: 64,
+    };
+    let publisher = make_driver_with_config(
+        broker.broker_url(),
+        "mqtt-mosquitto-recovery-publisher".to_string(),
+        "ferredge-mosquitto-recovery-publisher".to_string(),
+        Some(2),
+        reconnect.clone(),
+        true,
+        None,
+    );
+    let subscriber = make_driver_with_config(
+        broker.broker_url(),
+        "mqtt-mosquitto-recovery-subscriber".to_string(),
+        "ferredge-mosquitto-recovery-subscriber".to_string(),
+        Some(2),
+        reconnect,
+        true,
+        None,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    block_on(subscriber.start()).expect("subscriber should connect");
+    block_on(subscriber.subscribe(
+        subscribe_packet(&subscriber, "sub-recovery-1", "ferredge/it/recovery"),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("subscriber should subscribe before outage");
+    block_on(subscriber.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("subscriber listener should start");
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.start_listening(RecordingSink {
+        events: Arc::new(Mutex::new(Vec::new())),
+    }))
+    .expect("publisher listener should start");
+
+    broker.stop_broker();
+    thread::sleep(Duration::from_millis(400));
+
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "pub-recovery-1",
+        "ferredge/it/recovery",
+        b"queued-recovery-ok",
+        BrokerMessageOptions::default(),
+    )))
+    .expect("publisher should queue publish during outage");
+
+    broker.start_broker();
+
+    let event = wait_for_event_payload(&events, b"queued-recovery-ok");
+    assert_eq!(
+        event.address,
+        Address::Channel("ferredge/it/recovery".to_string())
+    );
+    assert_eq!(
+        subscriber
+            .listener_status()
+            .expect("subscriber listener status should be readable"),
+        MqttListenerStatus::Running
+    );
+    assert_eq!(
+        publisher
+            .listener_status()
+            .expect("publisher listener status should be readable"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
 }

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -19,6 +19,17 @@ use crate::{
     MqttDriver, MqttListenerStatus,
 };
 
+const MOSQUITTO_START_TIMEOUT_SECS: u64 = 5;
+const MOSQUITTO_EVENT_WAIT_TIMEOUT_SECS: u64 = 5;
+const MOSQUITTO_POLL_INTERVAL_MS: u64 = 25;
+const MOSQUITTO_CONNECT_RETRY_INTERVAL_MS: u64 = 50;
+const MOSQUITTO_SUBSCRIBER_STARTUP_MS: u64 = 200;
+const MOSQUITTO_UNSUBSCRIBE_SETTLE_MS: u64 = 500;
+const MOSQUITTO_RESTART_DOWN_WAIT_MS: u64 = 400;
+const MOSQUITTO_RECONNECT_SETTLE_MS: u64 = 1_200;
+const MOSQUITTO_KEEPALIVE_SHORT_SECS: u64 = 5;
+const MOSQUITTO_KEEPALIVE_LONG_SECS: u64 = 35;
+
 fn block_on<F: core::future::Future>(future: F) -> F::Output {
     static RUNTIME: OnceLock<StackRuntime> = OnceLock::new();
     RUNTIME.get_or_init(StackRuntime::default).block_on(future)
@@ -123,13 +134,13 @@ impl MosquittoGuard {
             .expect("mosquitto should spawn");
         self.child = Some(child);
 
-        let deadline = Instant::now() + Duration::from_secs(5);
+        let deadline = Instant::now() + Duration::from_secs(MOSQUITTO_START_TIMEOUT_SECS);
         loop {
             if TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
                 break;
             }
             assert!(Instant::now() < deadline, "mosquitto should start before timeout");
-            thread::sleep(Duration::from_millis(25));
+            thread::sleep(Duration::from_millis(MOSQUITTO_POLL_INTERVAL_MS));
         }
     }
 
@@ -240,7 +251,7 @@ fn publish_packet(
 }
 
 fn wait_for_event_payload(events: &Arc<Mutex<Vec<RoutedEvent>>>, payload: &[u8]) -> RoutedEvent {
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(MOSQUITTO_EVENT_WAIT_TIMEOUT_SECS);
     loop {
         if let Some(event) = events
             .lock()
@@ -252,7 +263,23 @@ fn wait_for_event_payload(events: &Arc<Mutex<Vec<RoutedEvent>>>, payload: &[u8])
             return event;
         }
         assert!(Instant::now() < deadline, "expected inbound MQTT event");
-        thread::sleep(Duration::from_millis(25));
+        thread::sleep(Duration::from_millis(MOSQUITTO_POLL_INTERVAL_MS));
+    }
+}
+
+fn wait_for_driver_start(driver: &MqttDriver) {
+    let deadline = Instant::now() + Duration::from_secs(MOSQUITTO_START_TIMEOUT_SECS);
+    loop {
+        match block_on(driver.start()) {
+            Ok(()) => return,
+            Err(error) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "driver should connect before timeout: {error}"
+                );
+                thread::sleep(Duration::from_millis(MOSQUITTO_CONNECT_RETRY_INTERVAL_MS));
+            }
+        }
     }
 }
 
@@ -333,7 +360,7 @@ fn mosquitto_extended_client_flow() {
     }))
     .expect("listener should start");
 
-    thread::sleep(Duration::from_millis(200));
+    thread::sleep(Duration::from_millis(MOSQUITTO_SUBSCRIBER_STARTUP_MS));
 
     let pub_status = ProcessCommand::new("mosquitto_pub")
         .args([
@@ -375,7 +402,7 @@ fn mosquitto_extended_client_flow() {
         .stderr(Stdio::null())
         .spawn()
         .expect("mosquitto_sub should spawn");
-    thread::sleep(Duration::from_millis(200));
+    thread::sleep(Duration::from_millis(MOSQUITTO_SUBSCRIBER_STARTUP_MS));
 
     block_on(publisher.publish(publish_packet(
         &publisher,
@@ -417,7 +444,7 @@ fn mosquitto_extended_client_flow() {
         .status()
         .expect("mosquitto_pub should run after unsubscribe");
     assert!(pub_status.success());
-    thread::sleep(Duration::from_millis(500));
+    thread::sleep(Duration::from_millis(MOSQUITTO_UNSUBSCRIBE_SETTLE_MS));
     assert_eq!(events.lock().expect("events lock").len(), prior_len);
 
     block_on(publisher.stop()).expect("publisher should stop cleanly");
@@ -445,13 +472,13 @@ fn mosquitto_keepalive_client_flow_five_seconds() {
         Some(2),
     );
 
-    block_on(driver.start()).expect("driver should connect");
+    wait_for_driver_start(&driver);
     block_on(driver.start_listening(RecordingSink {
         events: Arc::new(Mutex::new(Vec::new())),
     }))
     .expect("listener should start");
 
-    thread::sleep(Duration::from_secs(5));
+    thread::sleep(Duration::from_secs(MOSQUITTO_KEEPALIVE_SHORT_SECS));
 
     assert_eq!(
         driver.listener_status().expect("listener status should be readable"),
@@ -559,7 +586,7 @@ fn mosquitto_keepalive_client_flow_thirty_five_seconds() {
     }))
     .expect("listener should start");
 
-    thread::sleep(Duration::from_secs(35));
+    thread::sleep(Duration::from_secs(MOSQUITTO_KEEPALIVE_LONG_SECS));
 
     assert_eq!(
         driver.listener_status().expect("listener status should be readable"),
@@ -600,7 +627,7 @@ fn mosquitto_listener_reconnects_after_broker_restart_for_publish() {
     .expect("listener should start");
 
     broker.stop_broker();
-    thread::sleep(Duration::from_millis(400));
+    thread::sleep(Duration::from_millis(MOSQUITTO_RESTART_DOWN_WAIT_MS));
     broker.start_broker();
 
     let sub_child = ProcessCommand::new("mosquitto_sub")
@@ -623,7 +650,7 @@ fn mosquitto_listener_reconnects_after_broker_restart_for_publish() {
         .spawn()
         .expect("mosquitto_sub should spawn");
 
-    thread::sleep(Duration::from_millis(1200));
+    thread::sleep(Duration::from_millis(MOSQUITTO_RECONNECT_SETTLE_MS));
 
     block_on(driver.publish(publish_packet(
         &driver,
@@ -682,7 +709,7 @@ fn mosquitto_listener_fails_after_reconnect_attempt_budget_exhausted() {
 
     broker.stop_broker();
 
-    let deadline = Instant::now() + Duration::from_secs(5);
+    let deadline = Instant::now() + Duration::from_secs(MOSQUITTO_EVENT_WAIT_TIMEOUT_SECS);
     loop {
         let status = driver
             .listener_status()
@@ -694,7 +721,7 @@ fn mosquitto_listener_fails_after_reconnect_attempt_budget_exhausted() {
             Instant::now() < deadline,
             "listener should fail after reconnect attempts are exhausted"
         );
-        thread::sleep(Duration::from_millis(25));
+        thread::sleep(Duration::from_millis(MOSQUITTO_POLL_INTERVAL_MS));
     }
 
     match driver
@@ -712,7 +739,7 @@ fn mosquitto_listener_fails_after_reconnect_attempt_budget_exhausted() {
 
 #[test]
 #[ignore = "requires local mosquitto process and escalated execution"]
-fn mosquitto_replays_subscriptions_and_queued_publish_after_restart() {
+fn mosquitto_replays_subscriptions_after_restart() {
     let mut broker = MosquittoGuard::start();
     let reconnect = BrokerReconnectConfig {
         enabled: true,
@@ -725,19 +752,10 @@ fn mosquitto_replays_subscriptions_and_queued_publish_after_restart() {
         queue_requests_while_disconnected: true,
         max_queued_requests: 64,
     };
-    let publisher = make_driver_with_config(
-        broker.broker_url(),
-        "mqtt-mosquitto-recovery-publisher".to_string(),
-        "ferredge-mosquitto-recovery-publisher".to_string(),
-        Some(2),
-        reconnect.clone(),
-        true,
-        None,
-    );
     let subscriber = make_driver_with_config(
         broker.broker_url(),
-        "mqtt-mosquitto-recovery-subscriber".to_string(),
-        "ferredge-mosquitto-recovery-subscriber".to_string(),
+        "mqtt-mosquitto-resub-subscriber".to_string(),
+        "ferredge-mosquitto-resub-subscriber".to_string(),
         Some(2),
         reconnect,
         true,
@@ -758,27 +776,30 @@ fn mosquitto_replays_subscriptions_and_queued_publish_after_restart() {
     }))
     .expect("subscriber listener should start");
 
-    block_on(publisher.start()).expect("publisher should connect");
-    block_on(publisher.start_listening(RecordingSink {
-        events: Arc::new(Mutex::new(Vec::new())),
-    }))
-    .expect("publisher listener should start");
-
     broker.stop_broker();
-    thread::sleep(Duration::from_millis(400));
-
-    block_on(publisher.publish(publish_packet(
-        &publisher,
-        "pub-recovery-1",
-        "ferredge/it/recovery",
-        b"queued-recovery-ok",
-        BrokerMessageOptions::default(),
-    )))
-    .expect("publisher should queue publish during outage");
-
+    thread::sleep(Duration::from_millis(MOSQUITTO_RESTART_DOWN_WAIT_MS));
     broker.start_broker();
 
-    let event = wait_for_event_payload(&events, b"queued-recovery-ok");
+    thread::sleep(Duration::from_millis(MOSQUITTO_RECONNECT_SETTLE_MS));
+
+    let pub_status = ProcessCommand::new("mosquitto_pub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/recovery",
+            "-m",
+            "resub-ok",
+        ])
+        .status()
+        .expect("mosquitto_pub should run after broker restart");
+    assert!(pub_status.success());
+
+    let event = wait_for_event_payload(&events, b"resub-ok");
     assert_eq!(
         event.address,
         Address::Channel("ferredge/it/recovery".to_string())
@@ -789,13 +810,75 @@ fn mosquitto_replays_subscriptions_and_queued_publish_after_restart() {
             .expect("subscriber listener status should be readable"),
         MqttListenerStatus::Running
     );
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_replays_queued_publish_after_restart() {
+    let mut broker = MosquittoGuard::start();
+    let driver = make_driver_with_config(
+        broker.broker_url(),
+        "mqtt-mosquitto-queued-recovery".to_string(),
+        "ferredge-mosquitto-queued-recovery".to_string(),
+        Some(2),
+        BrokerReconnectConfig {
+            enabled: true,
+            initial_delay_ms: 100,
+            max_delay_ms: 500,
+            strategy: BrokerBackoffStrategy::Exponential,
+            multiplier: 2,
+            max_attempts: None,
+            replay_subscriptions: true,
+            queue_requests_while_disconnected: true,
+            max_queued_requests: 64,
+        },
+        true,
+        None,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.subscribe(
+        subscribe_packet(&driver, "sub-queued-recovery-1", "ferredge/it/recovery/out"),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("driver should subscribe before outage");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("driver listener should start");
+
+    broker.stop_broker();
+    thread::sleep(Duration::from_millis(MOSQUITTO_RESTART_DOWN_WAIT_MS));
+
+    block_on(driver.publish(publish_packet(
+        &driver,
+        "pub-queued-recovery-1",
+        "ferredge/it/recovery/out",
+        b"queued-recovery-ok",
+        BrokerMessageOptions {
+            delivery: Some(DeliveryGuarantee::AtLeastOnce),
+            ..BrokerMessageOptions::default()
+        },
+    )))
+    .expect("driver should queue publish during outage");
+
+    broker.start_broker();
+
+    let event = wait_for_event_payload(&events, b"queued-recovery-ok");
     assert_eq!(
-        publisher
+        event.address,
+        Address::Channel("ferredge/it/recovery/out".to_string())
+    );
+    assert_eq!(
+        driver
             .listener_status()
-            .expect("publisher listener status should be readable"),
+            .expect("driver listener status should be readable"),
         MqttListenerStatus::Running
     );
 
-    block_on(publisher.stop()).expect("publisher should stop cleanly");
-    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+    block_on(driver.stop()).expect("driver should stop cleanly");
 }

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -12,7 +12,8 @@ use ferredge_core::prelude::{
     BrokerSubscriptionProtocolOptions, Command, Correlation, DeliveryGuarantee, Device,
     DeviceEndpoint, DeviceStatus, EventSink, EventSource, Intent, Lifecycle, Map,
     MqttConnectProperties, MqttEndpointConfig, MqttMessageOptions, MqttPayloadFormat,
-    MqttProtocolVersion, MqttSubscriptionOptions, PubSub, RoutedEvent, TransportMeta,
+    MqttProtocolVersion, MqttSubscriptionOptions, MqttWillConfig, PubSub, RoutedEvent,
+    TransportMeta,
 };
 
 use crate::{
@@ -575,6 +576,134 @@ fn mosquitto_v5_complex_property_roundtrip() {
 
     block_on(publisher.stop()).expect("publisher should stop cleanly");
     block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+fn mosquitto_will_publishes_after_ungraceful_driver_drop() {
+    let broker = MosquittoGuard::start();
+    let will_topic = "ferredge/it/will";
+    let subscriber = ProcessCommand::new("mosquitto_sub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            will_topic,
+            "-C",
+            "1",
+            "-W",
+            "5",
+            "-F",
+            "%t|%p|%C|%D|%E|%F|%R|%P",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mosquitto_sub should spawn");
+    thread::sleep(Duration::from_millis(MOSQUITTO_SUBSCRIBER_STARTUP_MS));
+
+    let mut driver = make_named_driver(
+        broker.broker_url(),
+        "mqtt-will-publisher",
+        "ferredge-mosquitto-will-publisher",
+    );
+    if let DeviceEndpoint::Mqtt(config) = &mut driver.dvc.endpoint {
+        config.will = Some(MqttWillConfig {
+            topic: will_topic.to_string(),
+            payload: b"offline".to_vec(),
+            delivery: Some(DeliveryGuarantee::AtLeastOnce),
+            retain: true,
+            delay_interval_secs: Some(1),
+            payload_format: Some(MqttPayloadFormat::Utf8),
+            message_expiry_interval_secs: Some(30),
+            content_type: Some("text/plain".to_string()),
+            response_topic: Some("ferredge/it/will/reply".to_string()),
+            correlation_data: Some(b"will-corr".to_vec()),
+            user_properties: vec![("source".to_string(), "ferredge".to_string())],
+        });
+    }
+
+    block_on(driver.start()).expect("driver should connect with will configured");
+    thread::sleep(Duration::from_millis(MOSQUITTO_SUBSCRIBER_STARTUP_MS));
+    drop(driver);
+
+    let output = subscriber
+        .wait_with_output()
+        .expect("mosquitto_sub should finish after will publish");
+    assert!(output.status.success(), "will subscriber should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(will_topic), "missing will topic: {stdout}");
+    assert!(stdout.contains("offline"), "missing will payload: {stdout}");
+    assert!(stdout.contains("text/plain"), "missing will content type: {stdout}");
+    assert!(stdout.contains("will-corr"), "missing will correlation data: {stdout}");
+    assert!(stdout.contains("30"), "missing will expiry: {stdout}");
+    assert!(
+        stdout.contains("ferredge/it/will/reply"),
+        "missing will response topic: {stdout}"
+    );
+    assert!(stdout.contains("source"), "missing will user property key: {stdout}");
+    assert!(stdout.contains("ferredge"), "missing will user property value: {stdout}");
+}
+
+#[test]
+fn mosquitto_v5_topic_alias_publish_is_accepted_by_broker() {
+    let broker = MosquittoGuard::start();
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        "mqtt-topic-alias-publisher",
+        "ferredge-mosquitto-topic-alias-publisher",
+    );
+    let subscriber = ProcessCommand::new("mosquitto_sub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/topic-alias",
+            "-C",
+            "1",
+            "-W",
+            "5",
+            "-F",
+            "%A|%t|%p",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mosquitto_sub should spawn");
+    thread::sleep(Duration::from_millis(MOSQUITTO_SUBSCRIBER_STARTUP_MS));
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "pub-topic-alias-1",
+        "ferredge/it/topic-alias",
+        b"alias-ok",
+        BrokerMessageOptions {
+            protocol: Some(BrokerMessageProtocolOptions::Mqtt(MqttMessageOptions {
+                topic_alias: Some(7),
+                ..MqttMessageOptions::default()
+            })),
+            ..BrokerMessageOptions::default()
+        },
+    )))
+    .expect("publisher should publish with topic alias");
+
+    let output = subscriber
+        .wait_with_output()
+        .expect("mosquitto_sub should finish after topic alias publish");
+    assert!(output.status.success(), "topic alias subscriber should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ferredge/it/topic-alias"), "missing topic: {stdout}");
+    assert!(stdout.contains("alias-ok"), "missing payload: {stdout}");
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
 }
 
 #[test]

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -10,7 +10,8 @@ use ferredge_core::prelude::{
     Address, BrokerAddress, BrokerBackoffStrategy, BrokerMessageOptions, BrokerReconnectConfig,
     BrokerSubscriptionOptions, BrokerChannelKind, Command, Correlation, DeliveryGuarantee, Device,
     DeviceEndpoint, DeviceStatus, EventSink, EventSource, Intent, Lifecycle, Map,
-    MqttEndpointConfig, MqttProtocolVersion, PubSub, RoutedEvent, TransportMeta,
+    MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion, PubSub, RoutedEvent,
+    TransportMeta,
 };
 
 use crate::{
@@ -84,6 +85,7 @@ fn make_driver_with_config(
             clean_start,
             session_expiry_secs,
             topic_prefix: None,
+            connect_properties: MqttConnectProperties::default(),
             reconnect,
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -1,0 +1,527 @@
+use std::{
+    net::{TcpListener, TcpStream},
+    process::{Child, Command as ProcessCommand, Stdio},
+    sync::{Arc, Mutex, OnceLock},
+    thread,
+    time::{Duration, Instant},
+};
+
+use ferredge_core::prelude::{
+    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions,
+    Command, Correlation, DeliveryGuarantee, Device, DeviceEndpoint, DeviceStatus, EventSink,
+    EventSource, Intent, Lifecycle, Map, MqttEndpointConfig, MqttProtocolVersion, PubSub,
+    RoutedEvent, TransportMeta,
+};
+
+use crate::{
+    runtime_stack::StackRuntime,
+    types::{MqttCommandRef, MqttPacketRequest},
+    MqttDriver, MqttListenerStatus,
+};
+
+fn block_on<F: core::future::Future>(future: F) -> F::Output {
+    static RUNTIME: OnceLock<StackRuntime> = OnceLock::new();
+    RUNTIME.get_or_init(StackRuntime::default).block_on(future)
+}
+
+fn make_driver_with_client_id_and_keepalive(
+    broker: String,
+    device_id: String,
+    client_id: String,
+    keepalive_secs: Option<u16>,
+) -> MqttDriver {
+    MqttDriver::new(Device {
+        id: device_id,
+        name: "MQTT Mosquitto Device".to_string(),
+        status: DeviceStatus::Online,
+        endpoint: DeviceEndpoint::mqtt(MqttEndpointConfig {
+            broker,
+            client_id,
+            auth: None,
+            tls: None,
+            keepalive_secs,
+            clean_start: true,
+            session_expiry_secs: None,
+            topic_prefix: None,
+            supported_versions: vec![MqttProtocolVersion::V5_0],
+        }),
+        metadata: None,
+        max_connections: Some(4),
+        resources: Map::default(),
+        message_endpoints: Vec::new(),
+    })
+}
+
+fn make_named_driver(broker: String, device_id: &str, client_id: &str) -> MqttDriver {
+    make_driver_with_client_id_and_keepalive(
+        broker,
+        device_id.to_string(),
+        client_id.to_string(),
+        Some(5),
+    )
+}
+
+fn reserve_free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("free port probe should bind")
+        .local_addr()
+        .expect("free port probe should have addr")
+        .port()
+}
+
+struct MosquittoGuard {
+    child: Child,
+    port: u16,
+}
+
+impl MosquittoGuard {
+    fn start() -> Self {
+        let port = reserve_free_port();
+        let child = ProcessCommand::new("mosquitto")
+            .args(["-p", &port.to_string(), "-v"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("mosquitto should spawn");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "mosquitto should start before timeout");
+            thread::sleep(Duration::from_millis(25));
+        }
+
+        Self { child, port }
+    }
+
+    fn host(&self) -> String {
+        "127.0.0.1".to_string()
+    }
+
+    fn port_string(&self) -> String {
+        self.port.to_string()
+    }
+
+    fn broker_url(&self) -> String {
+        format!("mqtt://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for MosquittoGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct RecordingSink {
+    events: Arc<Mutex<Vec<RoutedEvent>>>,
+}
+
+impl EventSink for RecordingSink {
+    type Event = RoutedEvent;
+    type Error = ();
+
+    fn handle(&mut self, event: Self::Event) -> Result<(), Self::Error> {
+        self.events.lock().expect("recording sink lock").push(event);
+        Ok(())
+    }
+}
+
+fn subscribe_packet(driver: &MqttDriver, id: &str, topic: &str) -> MqttPacketRequest {
+    MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: id.to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Subscribe {
+                channel: BrokerAddress {
+                    name: topic.to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+                options: BrokerSubscriptionOptions::default(),
+            },
+            correlation: None,
+        },
+    })
+    .expect("subscribe packet should build")
+}
+
+fn unsubscribe_packet(driver: &MqttDriver, id: &str, topic: &str) -> MqttPacketRequest {
+    MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: id.to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Unsubscribe {
+                channel: BrokerAddress {
+                    name: topic.to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+            },
+            correlation: None,
+        },
+    })
+    .expect("unsubscribe packet should build")
+}
+
+fn publish_packet(
+    driver: &MqttDriver,
+    id: &str,
+    topic: &str,
+    payload: &[u8],
+    options: BrokerMessageOptions,
+) -> MqttPacketRequest {
+    MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: id.to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Send {
+                channel: BrokerAddress {
+                    name: topic.to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+                payload: payload.to_vec(),
+                options,
+            },
+            correlation: None,
+        },
+    })
+    .expect("publish packet should build")
+}
+
+fn wait_for_event_payload(events: &Arc<Mutex<Vec<RoutedEvent>>>, payload: &[u8]) -> RoutedEvent {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(event) = events
+            .lock()
+            .expect("events lock")
+            .iter()
+            .find(|event| event.payload == payload)
+            .cloned()
+        {
+            return event;
+        }
+        assert!(Instant::now() < deadline, "expected inbound MQTT event");
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn assert_qos_roundtrip(broker: &MosquittoGuard, delivery: DeliveryGuarantee, suffix: &str) {
+    let topic = format!("ferredge/it/qos/{suffix}");
+    let subscriber = make_named_driver(
+        broker.broker_url(),
+        &format!("mqtt-subscriber-{suffix}"),
+        &format!("ferredge-subscriber-{suffix}"),
+    );
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        &format!("mqtt-publisher-{suffix}"),
+        &format!("ferredge-publisher-{suffix}"),
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let payload = format!("payload-{suffix}");
+
+    block_on(subscriber.start()).expect("subscriber should connect");
+    block_on(subscriber.subscribe(
+        subscribe_packet(&subscriber, &format!("sub-{suffix}"), &topic),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("subscriber should subscribe");
+    block_on(subscriber.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("subscriber listener should start");
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        &format!("pub-{suffix}"),
+        &topic,
+        payload.as_bytes(),
+        BrokerMessageOptions {
+            delivery: Some(delivery),
+            ..BrokerMessageOptions::default()
+        },
+    )))
+    .expect("publisher should publish");
+
+    let event = wait_for_event_payload(&events, payload.as_bytes());
+    assert_eq!(event.address, Address::Channel(topic));
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_extended_client_flow() {
+    let broker = MosquittoGuard::start();
+    let subscriber = make_named_driver(
+        broker.broker_url(),
+        "mqtt-mosquitto-subscriber",
+        "ferredge-mosquitto-subscriber",
+    );
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        "mqtt-mosquitto-publisher",
+        "ferredge-mosquitto-publisher",
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    block_on(subscriber.start()).expect("subscriber should connect");
+    block_on(subscriber.subscribe(
+        subscribe_packet(&subscriber, "sub-1", "ferredge/it/in"),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("subscriber should subscribe");
+    block_on(subscriber.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("listener should start");
+
+    thread::sleep(Duration::from_millis(200));
+
+    let pub_status = ProcessCommand::new("mosquitto_pub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/in",
+            "-m",
+            "inbound-ok",
+        ])
+        .status()
+        .expect("mosquitto_pub should run");
+    assert!(pub_status.success());
+
+    wait_for_event_payload(&events, b"inbound-ok");
+
+    block_on(publisher.start()).expect("publisher should connect");
+
+    let sub_child = ProcessCommand::new("mosquitto_sub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/out",
+            "-C",
+            "1",
+            "-W",
+            "5",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("mosquitto_sub should spawn");
+    thread::sleep(Duration::from_millis(200));
+
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "pub-1",
+        "ferredge/it/out",
+        b"outbound-ok",
+        BrokerMessageOptions::default(),
+    )))
+    .expect("publisher should publish");
+
+    let output = sub_child
+        .wait_with_output()
+        .expect("mosquitto_sub should finish");
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "outbound-ok");
+
+    block_on(subscriber.stop_listening()).expect("listener should stop before unsubscribe");
+    block_on(subscriber.unsubscribe(unsubscribe_packet(
+        &subscriber,
+        "unsub-1",
+        "ferredge/it/in",
+    )))
+    .expect("subscriber should unsubscribe");
+
+    let prior_len = events.lock().expect("events lock").len();
+    let pub_status = ProcessCommand::new("mosquitto_pub")
+        .args([
+            "-h",
+            broker.host().as_str(),
+            "-p",
+            broker.port_string().as_str(),
+            "-V",
+            "mqttv5",
+            "-t",
+            "ferredge/it/in",
+            "-m",
+            "should-not-arrive",
+        ])
+        .status()
+        .expect("mosquitto_pub should run after unsubscribe");
+    assert!(pub_status.success());
+    thread::sleep(Duration::from_millis(500));
+    assert_eq!(events.lock().expect("events lock").len(), prior_len);
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_qos_matrix_roundtrip() {
+    let broker = MosquittoGuard::start();
+
+    assert_qos_roundtrip(&broker, DeliveryGuarantee::BestEffort, "qos0");
+    assert_qos_roundtrip(&broker, DeliveryGuarantee::AtLeastOnce, "qos1");
+    assert_qos_roundtrip(&broker, DeliveryGuarantee::ExactlyOnce, "qos2");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_keepalive_client_flow_five_seconds() {
+    let broker = MosquittoGuard::start();
+    let driver = make_driver_with_client_id_and_keepalive(
+        broker.broker_url(),
+        "mqtt-mosquitto-keepalive-device".to_string(),
+        "ferredge-mosquitto-keepalive".to_string(),
+        Some(2),
+    );
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::new(Mutex::new(Vec::new())),
+    }))
+    .expect("listener should start");
+
+    thread::sleep(Duration::from_secs(5));
+
+    assert_eq!(
+        driver.listener_status().expect("listener status should be readable"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_v5_complex_property_roundtrip() {
+    let broker = MosquittoGuard::start();
+    let publisher = make_named_driver(
+        broker.broker_url(),
+        "mqtt-v5-publisher",
+        "ferredge-mosquitto-publisher",
+    );
+    let subscriber = make_named_driver(
+        broker.broker_url(),
+        "mqtt-v5-subscriber",
+        "ferredge-mosquitto-subscriber",
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    block_on(subscriber.start()).expect("subscriber should connect");
+    block_on(subscriber.subscribe(
+        subscribe_packet(&subscriber, "sub-v5-1", "ferredge/it/v5"),
+        RecordingSink {
+            events: Arc::clone(&events),
+        },
+    ))
+    .expect("subscriber should subscribe");
+    block_on(subscriber.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("subscriber listener should start");
+
+    block_on(publisher.start()).expect("publisher should connect");
+    block_on(publisher.publish(publish_packet(
+        &publisher,
+        "pub-v5-1",
+        "ferredge/it/v5",
+        br#"{"ok":true}"#,
+        BrokerMessageOptions {
+            delivery: Some(DeliveryGuarantee::BestEffort),
+            headers: vec![
+                ("content-type".to_string(), "application/json".to_string()),
+                ("x-trace".to_string(), "trace-123".to_string()),
+                ("x-origin".to_string(), "ferredge".to_string()),
+            ],
+            reply_to: Some("ferredge/it/reply".to_string()),
+            correlation_id: Some("corr-v5-123".to_string()),
+        },
+    )))
+    .expect("publisher should publish");
+
+    let event = wait_for_event_payload(&events, br#"{"ok":true}"#);
+    assert_eq!(
+        event.address,
+        Address::Channel("ferredge/it/v5".to_string())
+    );
+    assert_eq!(event.payload, br#"{"ok":true}"#.to_vec());
+    assert_eq!(
+        event.correlation,
+        Some(Correlation {
+            request_id: "corr-v5-123".to_string(),
+            reply_to: Some(Address::Channel("ferredge/it/reply".to_string())),
+        })
+    );
+
+    match event.transport {
+        Some(TransportMeta::Mqtt(meta)) => {
+            assert_eq!(meta.content_type, Some("application/json".to_string()));
+            assert_eq!(meta.response_topic, Some("ferredge/it/reply".to_string()));
+            assert_eq!(meta.correlation_data, Some("corr-v5-123".to_string()));
+            assert!(meta
+                .user_properties
+                .contains(&("x-trace".to_string(), "trace-123".to_string())));
+            assert!(meta
+                .user_properties
+                .contains(&("x-origin".to_string(), "ferredge".to_string())));
+        }
+        other => panic!("expected MQTT transport metadata, got {other:?}"),
+    }
+
+    block_on(publisher.stop()).expect("publisher should stop cleanly");
+    block_on(subscriber.stop()).expect("subscriber should stop cleanly");
+}
+
+#[test]
+#[ignore = "requires local mosquitto process and escalated execution"]
+fn mosquitto_keepalive_client_flow_thirty_five_seconds() {
+    let broker = MosquittoGuard::start();
+    let driver = make_driver_with_client_id_and_keepalive(
+        broker.broker_url(),
+        "mqtt-mosquitto-keepalive-long-device".to_string(),
+        "ferredge-mosquitto-keepalive-long".to_string(),
+        Some(10),
+    );
+
+    block_on(driver.start()).expect("driver should connect");
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::new(Mutex::new(Vec::new())),
+    }))
+    .expect("listener should start");
+
+    thread::sleep(Duration::from_secs(35));
+
+    assert_eq!(
+        driver.listener_status().expect("listener status should be readable"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+}

--- a/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
+++ b/crates/ferredge-proto-mqtt/src/mosquitto_tests.rs
@@ -17,9 +17,9 @@ use ferredge_core::prelude::{
 };
 
 use crate::{
+    MqttDriver, MqttListenerStatus,
     runtime_stack::StackRuntime,
     types::{MqttCommandRef, MqttPacketRequest},
-    MqttDriver, MqttListenerStatus,
 };
 
 const MOSQUITTO_START_TIMEOUT_SECS: u64 = 5;
@@ -144,7 +144,10 @@ impl MosquittoGuard {
             if TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
                 break;
             }
-            assert!(Instant::now() < deadline, "mosquitto should start before timeout");
+            assert!(
+                Instant::now() < deadline,
+                "mosquitto should start before timeout"
+            );
             thread::sleep(Duration::from_millis(MOSQUITTO_POLL_INTERVAL_MS));
         }
     }
@@ -422,15 +425,14 @@ fn mosquitto_extended_client_flow() {
         .wait_with_output()
         .expect("mosquitto_sub should finish");
     assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "outbound-ok");
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "outbound-ok"
+    );
 
     block_on(subscriber.stop_listening()).expect("listener should stop before unsubscribe");
-    block_on(subscriber.unsubscribe(unsubscribe_packet(
-        &subscriber,
-        "unsub-1",
-        "ferredge/it/in",
-    )))
-    .expect("subscriber should unsubscribe");
+    block_on(subscriber.unsubscribe(unsubscribe_packet(&subscriber, "unsub-1", "ferredge/it/in")))
+        .expect("subscriber should unsubscribe");
 
     let prior_len = events.lock().expect("events lock").len();
     let pub_status = ProcessCommand::new("mosquitto_pub")
@@ -486,7 +488,9 @@ fn mosquitto_keepalive_client_flow_five_seconds() {
     thread::sleep(Duration::from_secs(MOSQUITTO_KEEPALIVE_SHORT_SECS));
 
     assert_eq!(
-        driver.listener_status().expect("listener status should be readable"),
+        driver
+            .listener_status()
+            .expect("listener status should be readable"),
         MqttListenerStatus::Running
     );
 
@@ -564,12 +568,14 @@ fn mosquitto_v5_complex_property_roundtrip() {
             assert_eq!(meta.content_type, Some("application/json".to_string()));
             assert_eq!(meta.response_topic, Some("ferredge/it/reply".to_string()));
             assert_eq!(meta.correlation_data, Some("corr-v5-123".to_string()));
-            assert!(meta
-                .user_properties
-                .contains(&("x-trace".to_string(), "trace-123".to_string())));
-            assert!(meta
-                .user_properties
-                .contains(&("x-origin".to_string(), "ferredge".to_string())));
+            assert!(
+                meta.user_properties
+                    .contains(&("x-trace".to_string(), "trace-123".to_string()))
+            );
+            assert!(
+                meta.user_properties
+                    .contains(&("x-origin".to_string(), "ferredge".to_string()))
+            );
         }
         other => panic!("expected MQTT transport metadata, got {other:?}"),
     }
@@ -637,15 +643,27 @@ fn mosquitto_will_publishes_after_ungraceful_driver_drop() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains(will_topic), "missing will topic: {stdout}");
     assert!(stdout.contains("offline"), "missing will payload: {stdout}");
-    assert!(stdout.contains("text/plain"), "missing will content type: {stdout}");
-    assert!(stdout.contains("will-corr"), "missing will correlation data: {stdout}");
+    assert!(
+        stdout.contains("text/plain"),
+        "missing will content type: {stdout}"
+    );
+    assert!(
+        stdout.contains("will-corr"),
+        "missing will correlation data: {stdout}"
+    );
     assert!(stdout.contains("30"), "missing will expiry: {stdout}");
     assert!(
         stdout.contains("ferredge/it/will/reply"),
         "missing will response topic: {stdout}"
     );
-    assert!(stdout.contains("source"), "missing will user property key: {stdout}");
-    assert!(stdout.contains("ferredge"), "missing will user property value: {stdout}");
+    assert!(
+        stdout.contains("source"),
+        "missing will user property key: {stdout}"
+    );
+    assert!(
+        stdout.contains("ferredge"),
+        "missing will user property value: {stdout}"
+    );
 }
 
 #[test]
@@ -698,9 +716,15 @@ fn mosquitto_v5_topic_alias_publish_is_accepted_by_broker() {
     let output = subscriber
         .wait_with_output()
         .expect("mosquitto_sub should finish after topic alias publish");
-    assert!(output.status.success(), "topic alias subscriber should succeed");
+    assert!(
+        output.status.success(),
+        "topic alias subscriber should succeed"
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("ferredge/it/topic-alias"), "missing topic: {stdout}");
+    assert!(
+        stdout.contains("ferredge/it/topic-alias"),
+        "missing topic: {stdout}"
+    );
     assert!(stdout.contains("alias-ok"), "missing payload: {stdout}");
 
     block_on(publisher.stop()).expect("publisher should stop cleanly");
@@ -801,38 +825,40 @@ fn mosquitto_v5_subscription_identifier_and_no_local_work() {
     let topic = "ferredge/it/subopts";
 
     block_on(driver.start()).expect("driver should connect");
-    block_on(driver.subscribe(
-        MqttPacketRequest::try_from(MqttCommandRef {
-            device: &driver.dvc,
-            command: &Command {
-                id: "subopts-sub".to_string(),
-                source_device_id: None,
-                target_device_id: driver.dvc.id.clone(),
-                intent: Intent::Subscribe {
-                    channel: BrokerAddress {
-                        name: topic.to_string(),
-                        kind: Some(BrokerChannelKind::Topic),
+    block_on(
+        driver.subscribe(
+            MqttPacketRequest::try_from(MqttCommandRef {
+                device: &driver.dvc,
+                command: &Command {
+                    id: "subopts-sub".to_string(),
+                    source_device_id: None,
+                    target_device_id: driver.dvc.id.clone(),
+                    intent: Intent::Subscribe {
+                        channel: BrokerAddress {
+                            name: topic.to_string(),
+                            kind: Some(BrokerChannelKind::Topic),
+                        },
+                        options: BrokerSubscriptionOptions {
+                            delivery: Some(DeliveryGuarantee::AtLeastOnce),
+                            protocol: Some(BrokerSubscriptionProtocolOptions::Mqtt(
+                                MqttSubscriptionOptions {
+                                    no_local: true,
+                                    subscription_identifier: Some(41),
+                                    ..MqttSubscriptionOptions::default()
+                                },
+                            )),
+                            ..BrokerSubscriptionOptions::default()
+                        },
                     },
-                    options: BrokerSubscriptionOptions {
-                        delivery: Some(DeliveryGuarantee::AtLeastOnce),
-                        protocol: Some(BrokerSubscriptionProtocolOptions::Mqtt(
-                            MqttSubscriptionOptions {
-                                no_local: true,
-                                subscription_identifier: Some(41),
-                                ..MqttSubscriptionOptions::default()
-                            },
-                        )),
-                        ..BrokerSubscriptionOptions::default()
-                    },
+                    correlation: None,
                 },
-                correlation: None,
+            })
+            .expect("subscribe packet should build"),
+            RecordingSink {
+                events: Arc::clone(&events),
             },
-        })
-        .expect("subscribe packet should build"),
-        RecordingSink {
-            events: Arc::clone(&events),
-        },
-    ))
+        ),
+    )
     .expect("driver should subscribe");
     block_on(driver.start_listening(RecordingSink {
         events: Arc::clone(&events),
@@ -909,31 +935,33 @@ fn mosquitto_shared_subscriptions_load_balance() {
         (&subscriber_b, Arc::clone(&events_b), "shared-sub-b"),
     ] {
         block_on(driver.start()).expect("subscriber should connect");
-        block_on(driver.subscribe(
-            MqttPacketRequest::try_from(MqttCommandRef {
-                device: &driver.dvc,
-                command: &Command {
-                    id: sub_id.to_string(),
-                    source_device_id: None,
-                    target_device_id: driver.dvc.id.clone(),
-                    intent: Intent::Subscribe {
-                        channel: BrokerAddress {
-                            name: topic.to_string(),
-                            kind: Some(BrokerChannelKind::Topic),
+        block_on(
+            driver.subscribe(
+                MqttPacketRequest::try_from(MqttCommandRef {
+                    device: &driver.dvc,
+                    command: &Command {
+                        id: sub_id.to_string(),
+                        source_device_id: None,
+                        target_device_id: driver.dvc.id.clone(),
+                        intent: Intent::Subscribe {
+                            channel: BrokerAddress {
+                                name: topic.to_string(),
+                                kind: Some(BrokerChannelKind::Topic),
+                            },
+                            options: BrokerSubscriptionOptions {
+                                shared_group: Some("workers".to_string()),
+                                ..BrokerSubscriptionOptions::default()
+                            },
                         },
-                        options: BrokerSubscriptionOptions {
-                            shared_group: Some("workers".to_string()),
-                            ..BrokerSubscriptionOptions::default()
-                        },
+                        correlation: None,
                     },
-                    correlation: None,
+                })
+                .expect("shared subscribe should build"),
+                RecordingSink {
+                    events: Arc::clone(&events),
                 },
-            })
-            .expect("shared subscribe should build"),
-            RecordingSink {
-                events: Arc::clone(&events),
-            },
-        ))
+            ),
+        )
         .expect("subscriber should subscribe shared topic");
         block_on(driver.start_listening(RecordingSink {
             events: Arc::clone(&events),
@@ -996,7 +1024,9 @@ fn mosquitto_keepalive_client_flow_thirty_five_seconds() {
     thread::sleep(Duration::from_secs(MOSQUITTO_KEEPALIVE_LONG_SECS));
 
     assert_eq!(
-        driver.listener_status().expect("listener status should be readable"),
+        driver
+            .listener_status()
+            .expect("listener status should be readable"),
         MqttListenerStatus::Running
     );
 
@@ -1077,7 +1107,9 @@ fn mosquitto_listener_reconnects_after_broker_restart_for_publish() {
         "reconnected-outbound-ok"
     );
     assert_eq!(
-        driver.listener_status().expect("listener status should be readable"),
+        driver
+            .listener_status()
+            .expect("listener status should be readable"),
         MqttListenerStatus::Running
     );
 
@@ -1136,7 +1168,10 @@ fn mosquitto_listener_fails_after_reconnect_attempt_budget_exhausted() {
         .expect("listener status should be readable")
     {
         MqttListenerStatus::Failed(error) => {
-            assert!(!error.is_empty(), "failed listener should retain reconnect error");
+            assert!(
+                !error.is_empty(),
+                "failed listener should retain reconnect error"
+            );
         }
         other => panic!("expected failed listener status, got {other:?}"),
     }

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -8,7 +8,7 @@ use std::{
 
 use ferredge_core::prelude::*;
 #[cfg(feature = "std")]
-use runtime_stack::{StackRuntime, StackSocket};
+use runtime_stack::StackSocket;
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
 
@@ -139,8 +139,7 @@ pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
 }
 
 #[cfg(feature = "std")]
-pub(crate) fn send_packet_request(
-    runtime: &StackRuntime,
+pub(crate) async fn send_packet_request_async(
     session: &mut MqttClientSession,
     device_id: &str,
     request: MqttPacketRequest,
@@ -157,7 +156,7 @@ pub(crate) fn send_packet_request(
     let events = session
         .connection
         .checked_send(packet_request_into_packet(request));
-    let _ = handle_connection_events(runtime, session, device_id, events)?;
+    let _ = handle_connection_events_async(session, device_id, events).await?;
     Ok(())
 }
 
@@ -287,16 +286,6 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
 }
 
 #[cfg(feature = "std")]
-pub(crate) fn read_from_session(
-    runtime: &StackRuntime,
-    session: &mut MqttClientSession,
-    device_id: &str,
-    timeout: Option<Duration>,
-) -> Result<Vec<RoutedMessage>, String> {
-    runtime.block_on(read_from_session_async(session, device_id, timeout))
-}
-
-#[cfg(feature = "std")]
 pub(crate) async fn read_from_session_async(
     session: &mut MqttClientSession,
     device_id: &str,
@@ -323,16 +312,6 @@ pub(crate) async fn read_from_session_async(
         }
         Err(error) => Err(format!("failed reading MQTT stream: {error:?}")),
     }
-}
-
-#[cfg(feature = "std")]
-pub(crate) fn handle_connection_events(
-    runtime: &StackRuntime,
-    session: &mut MqttClientSession,
-    device_id: &str,
-    events: Vec<mqtt::connection::Event>,
-) -> Result<Vec<RoutedMessage>, String> {
-    runtime.block_on(handle_connection_events_async(session, device_id, events))
 }
 
 #[cfg(feature = "std")]

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -445,6 +445,9 @@ pub(crate) fn routed_event_from_v5_publish(
 ) -> RoutedEvent {
     let mut correlation_id = None;
     let mut reply_to = None;
+    let mut content_type = None;
+    let mut subscription_identifiers = Vec::new();
+    let mut user_properties = Vec::new();
     for prop in packet.props() {
         match prop {
             mqtt::packet::Property::CorrelationData(prop) => {
@@ -453,16 +456,29 @@ pub(crate) fn routed_event_from_v5_publish(
             mqtt::packet::Property::ResponseTopic(prop) => {
                 reply_to = Some(Address::Channel(prop.val().to_string()));
             }
+            mqtt::packet::Property::ContentType(prop) => {
+                content_type = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::SubscriptionIdentifier(prop) => {
+                subscription_identifiers.push(prop.val());
+            }
+            mqtt::packet::Property::UserProperty(prop) => {
+                user_properties.push((prop.key().to_string(), prop.val().to_string()));
+            }
             _ => {}
         }
     }
+    let response_topic = reply_to.as_ref().and_then(|address| match address {
+        Address::Channel(channel) => Some(channel.clone()),
+        Address::Resource(_) => None,
+    });
     RoutedEvent {
         source: mqtt_source(device_id),
         address: Address::Channel(packet.topic_name().to_string()),
         payload: packet.payload().as_slice().to_vec(),
         correlation: if correlation_id.is_some() || reply_to.is_some() {
             Some(Correlation {
-                request_id: correlation_id.unwrap_or_default(),
+                request_id: correlation_id.clone().unwrap_or_default(),
                 reply_to,
             })
         } else {
@@ -474,6 +490,11 @@ pub(crate) fn routed_event_from_v5_publish(
             retain: packet.retain(),
             duplicate: packet.dup(),
             packet_id: packet.packet_id(),
+            content_type,
+            response_topic,
+            correlation_data: correlation_id.clone(),
+            subscription_identifiers,
+            user_properties,
         })),
     }
 }
@@ -494,6 +515,11 @@ pub(crate) fn routed_event_from_v3_publish(
             retain: packet.retain(),
             duplicate: packet.dup(),
             packet_id: packet.packet_id(),
+            content_type: None,
+            response_topic: None,
+            correlation_data: None,
+            subscription_identifiers: Vec::new(),
+            user_properties: Vec::new(),
         })),
     }
 }

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -19,6 +19,14 @@ pub(crate) struct MqttClientSession {
     pub(crate) stream: TcpStream,
     pub(crate) connection: mqtt::Connection<mqtt::role::Client>,
     pub(crate) pending_command_ids: HashMap<u16, String>,
+    pub(crate) pending_reply_routes: HashMap<String, PendingReplyRoute>,
+}
+
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub(crate) struct PendingReplyRoute {
+    pub(crate) command_id: String,
+    pub(crate) reply_to: Option<Address>,
 }
 
 #[cfg(feature = "std")]
@@ -121,6 +129,9 @@ pub(crate) fn send_packet_request(
     request: MqttPacketRequest,
 ) -> Result<(), String> {
     let request = assign_runtime_packet_id(session, request)?;
+    if let Some((correlation_key, route)) = pending_reply_route_from_packet(&request) {
+        session.pending_reply_routes.insert(correlation_key, route);
+    }
     if let Some(packet_id) = packet_request_packet_id(&request.packet) {
         session
             .pending_command_ids
@@ -302,9 +313,12 @@ pub(crate) fn handle_connection_events(
                     .map_err(|e| format!("failed to write MQTT packet: {e}"))?;
             }
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
-                if let Some(message) =
-                    routed_message_from_packet(&mut session.pending_command_ids, device_id, packet)
-                {
+                if let Some(message) = routed_message_from_packet(
+                    &mut session.pending_command_ids,
+                    &mut session.pending_reply_routes,
+                    device_id,
+                    packet,
+                ) {
                     routed.push(message);
                 }
             }
@@ -326,13 +340,14 @@ pub(crate) fn handle_connection_events(
 #[cfg(feature = "std")]
 pub(crate) fn routed_message_from_packet(
     pending_command_ids: &mut HashMap<u16, String>,
+    pending_reply_routes: &mut HashMap<String, PendingReplyRoute>,
     device_id: &str,
     packet: mqtt::packet::Packet,
 ) -> Option<RoutedMessage> {
     match packet {
-        mqtt::packet::Packet::V5_0Publish(packet) => Some(RoutedMessage::Event(
-            routed_event_from_v5_publish(device_id, &packet),
-        )),
+        mqtt::packet::Packet::V5_0Publish(packet) => {
+            routed_reply_or_event_from_v5_publish(pending_reply_routes, device_id, &packet)
+        }
         mqtt::packet::Packet::V3_1_1Publish(packet) => Some(RoutedMessage::Event(
             routed_event_from_v3_publish(device_id, &packet),
         )),
@@ -431,6 +446,41 @@ pub(crate) fn routed_message_from_packet(
 }
 
 #[cfg(feature = "std")]
+fn pending_reply_route_from_packet(
+    request: &MqttPacketRequest,
+) -> Option<(String, PendingReplyRoute)> {
+    match &request.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            let mut correlation_key = None;
+            let mut reply_to = None;
+            for prop in packet.props() {
+                match prop {
+                    mqtt::packet::Property::CorrelationData(prop) => {
+                        correlation_key =
+                            Some(String::from_utf8_lossy(prop.val()).into_owned());
+                    }
+                    mqtt::packet::Property::ResponseTopic(prop) => {
+                        reply_to = Some(Address::Channel(prop.val().to_string()));
+                    }
+                    _ => {}
+                }
+            }
+
+            correlation_key.map(|correlation_key| {
+                (
+                    correlation_key,
+                    PendingReplyRoute {
+                        command_id: request.command_id.clone(),
+                        reply_to,
+                    },
+                )
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(feature = "std")]
 pub(crate) fn mqtt_source(device_id: &str) -> EndpointRef {
     EndpointRef {
         device_id: device_id.to_string(),
@@ -497,6 +547,78 @@ pub(crate) fn routed_event_from_v5_publish(
             user_properties,
         })),
     }
+}
+
+#[cfg(feature = "std")]
+fn routed_reply_or_event_from_v5_publish(
+    pending_reply_routes: &mut HashMap<String, PendingReplyRoute>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Publish,
+) -> Option<RoutedMessage> {
+    let mut correlation_key = None;
+    for prop in packet.props() {
+        if let mqtt::packet::Property::CorrelationData(prop) = prop {
+            correlation_key = Some(String::from_utf8_lossy(prop.val()).into_owned());
+            break;
+        }
+    }
+
+    if let Some(correlation_key) = correlation_key
+        && let Some(route) = pending_reply_routes.remove(&correlation_key)
+    {
+        return Some(RoutedMessage::Result(RoutedResult {
+            source: mqtt_source(device_id),
+            result: CommandResult {
+                command_id: route.command_id.clone(),
+                device_id: device_id.to_string(),
+                state: DeliveryState::Completed,
+                payload: Some(packet.payload().as_slice().to_vec()),
+                error: None,
+                correlation: Some(Correlation {
+                    request_id: route.command_id,
+                    reply_to: route.reply_to,
+                }),
+            },
+            transport: Some(TransportMeta::Mqtt(MqttMeta {
+                topic: packet.topic_name().to_string(),
+                qos: packet.qos() as u8,
+                retain: packet.retain(),
+                duplicate: packet.dup(),
+                packet_id: packet.packet_id(),
+                content_type: packet.props().iter().find_map(|prop| match prop {
+                    mqtt::packet::Property::ContentType(prop) => Some(prop.val().to_string()),
+                    _ => None,
+                }),
+                response_topic: packet.props().iter().find_map(|prop| match prop {
+                    mqtt::packet::Property::ResponseTopic(prop) => Some(prop.val().to_string()),
+                    _ => None,
+                }),
+                correlation_data: Some(correlation_key),
+                subscription_identifiers: packet
+                    .props()
+                    .iter()
+                    .filter_map(|prop| match prop {
+                        mqtt::packet::Property::SubscriptionIdentifier(prop) => Some(prop.val()),
+                        _ => None,
+                    })
+                    .collect(),
+                user_properties: packet
+                    .props()
+                    .iter()
+                    .filter_map(|prop| match prop {
+                        mqtt::packet::Property::UserProperty(prop) => {
+                            Some((prop.key().to_string(), prop.val().to_string()))
+                        }
+                        _ => None,
+                    })
+                    .collect(),
+            })),
+        }));
+    }
+
+    Some(RoutedMessage::Event(routed_event_from_v5_publish(
+        device_id, packet,
+    )))
 }
 
 #[cfg(feature = "std")]

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -1,25 +1,20 @@
-use std::{
-    collections::HashMap,
-    string::String,
-    time::Duration,
-    vec::Vec,
-};
+use std::{collections::HashMap, string::String, time::Duration, vec::Vec};
 
-use ferredge_core::prelude::*;
 use ferredge_core::prelude::RuntimeInstant as RuntimeInstantExt;
-use runtime_stack::StackSocket;
+use ferredge_core::prelude::*;
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
+use runtime_stack::StackSocket;
 
 use crate::convert::qos_from_delivery;
-use crate::types::{MqttPacketRequest, MqttWirePacket};
-use crate::{
-    MqttAuthChallenge, MqttAuthFlowReason, MqttAuthProvider, MqttAuthResponse, MqttAuthStage,
-};
 #[cfg(feature = "tokio-runtime")]
 use crate::runtime_stack;
 #[cfg(feature = "async-std-runtime")]
 use crate::runtime_stack;
+use crate::types::{MqttPacketRequest, MqttWirePacket};
+use crate::{
+    MqttAuthChallenge, MqttAuthFlowReason, MqttAuthProvider, MqttAuthResponse, MqttAuthStage,
+};
 
 type RuntimeMutex<T> = <runtime_stack::StackRuntime as AsyncRuntime>::Mutex<T>;
 type StackInstant = <runtime_stack::StackRuntime as AsyncRuntime>::Instant;
@@ -250,14 +245,12 @@ fn assign_runtime_packet_id(
     request: MqttPacketRequest,
 ) -> Result<MqttPacketRequest, String> {
     let maybe_packet_id = match &request.packet {
-        packet if publish_requires_packet_id(packet) => {
-            Some(
-                session
-                    .connection
-                    .acquire_packet_id()
-                    .map_err(|e| e.to_string())?,
-            )
-        }
+        packet if publish_requires_packet_id(packet) => Some(
+            session
+                .connection
+                .acquire_packet_id()
+                .map_err(|e| e.to_string())?,
+        ),
         MqttWirePacket::V5Subscribe(_)
         | MqttWirePacket::V3Subscribe(_)
         | MqttWirePacket::V5Unsubscribe(_)
@@ -277,7 +270,10 @@ fn assign_runtime_packet_id(
     }
 }
 
-fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<MqttPacketRequest, String> {
+fn rebuild_with_packet_id(
+    request: MqttPacketRequest,
+    packet_id: u16,
+) -> Result<MqttPacketRequest, String> {
     let command_id = request.command_id;
     let packet = match request.packet {
         MqttWirePacket::V5Publish(packet) => {
@@ -325,7 +321,11 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
             MqttWirePacket::V3Subscribe(rebuilt)
         }
         MqttWirePacket::V5Unsubscribe(packet) => {
-            let entries: Vec<String> = packet.entries().iter().map(|entry| entry.as_str().to_string()).collect();
+            let entries: Vec<String> = packet
+                .entries()
+                .iter()
+                .map(|entry| entry.as_str().to_string())
+                .collect();
             let entry_refs: Vec<&str> = entries.iter().map(String::as_str).collect();
             let rebuilt = mqtt::packet::v5_0::Unsubscribe::builder()
                 .packet_id(packet_id)
@@ -337,7 +337,11 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
             MqttWirePacket::V5Unsubscribe(rebuilt)
         }
         MqttWirePacket::V3Unsubscribe(packet) => {
-            let entries: Vec<String> = packet.entries().iter().map(|entry| entry.as_str().to_string()).collect();
+            let entries: Vec<String> = packet
+                .entries()
+                .iter()
+                .map(|entry| entry.as_str().to_string())
+                .collect();
             let entry_refs: Vec<&str> = entries.iter().map(String::as_str).collect();
             let rebuilt = mqtt::packet::v3_1_1::Unsubscribe::builder()
                 .packet_id(packet_id)
@@ -466,7 +470,10 @@ async fn process_incoming_auth_async(
         .map_err(|_| "failed to lock MQTT auth handler".to_string())?
         .clone();
     let Some(handler) = handler else {
-        return Err("mqtt broker requested enhanced authentication but no auth handler is configured".to_string());
+        return Err(
+            "mqtt broker requested enhanced authentication but no auth handler is configured"
+                .to_string(),
+        );
     };
     let Some(response) = handler.respond(challenge)? else {
         return Err("mqtt auth handler returned no response for broker challenge".to_string());
@@ -497,7 +504,9 @@ async fn process_outbound_auth_events_async(
                 session.last_activity = runtime.now();
             }
             mqtt::connection::Event::NotifyError(error) => {
-                return Err(format!("mqtt protocol error during auth exchange: {error:?}"));
+                return Err(format!(
+                    "mqtt protocol error during auth exchange: {error:?}"
+                ));
             }
             mqtt::connection::Event::RequestClose => {
                 return Err("mqtt auth exchange requested close".to_string());
@@ -586,7 +595,8 @@ fn build_auth_packet(
     }
     if let Some(authentication_data) = response.authentication_data {
         props.push(mqtt::packet::Property::AuthenticationData(
-            mqtt::packet::AuthenticationData::new(authentication_data).map_err(|e| e.to_string())?,
+            mqtt::packet::AuthenticationData::new(authentication_data)
+                .map_err(|e| e.to_string())?,
         ));
     }
     if let Some(reason_string) = &response.reason_string {
@@ -622,16 +632,16 @@ pub(crate) async fn disconnect_session(
     let events = match session.protocol_version {
         MqttProtocolVersion::V5_0 => {
             let disconnect = mqtt::packet::v5_0::Disconnect::builder()
-            .reason_code(mqtt::result_code::DisconnectReasonCode::NormalDisconnection)
-            .props(mqtt::packet::Properties::new())
-            .build()
-            .map_err(|e| e.to_string())?;
+                .reason_code(mqtt::result_code::DisconnectReasonCode::NormalDisconnection)
+                .props(mqtt::packet::Properties::new())
+                .build()
+                .map_err(|e| e.to_string())?;
             session.connection.checked_send(disconnect)
         }
         MqttProtocolVersion::V3_1_1 => {
             let disconnect = mqtt::packet::v3_1_1::Disconnect::builder()
-            .build()
-            .map_err(|e| e.to_string())?;
+                .build()
+                .map_err(|e| e.to_string())?;
             session.connection.checked_send(disconnect)
         }
     };
@@ -665,14 +675,14 @@ async fn send_keepalive_ping_if_due(
     let events = match session.protocol_version {
         MqttProtocolVersion::V5_0 => {
             let pingreq = mqtt::packet::v5_0::Pingreq::builder()
-            .build()
-            .map_err(|e| e.to_string())?;
+                .build()
+                .map_err(|e| e.to_string())?;
             session.connection.checked_send(pingreq)
         }
         MqttProtocolVersion::V3_1_1 => {
             let pingreq = mqtt::packet::v3_1_1::Pingreq::builder()
-            .build()
-            .map_err(|e| e.to_string())?;
+                .build()
+                .map_err(|e| e.to_string())?;
             session.connection.checked_send(pingreq)
         }
     };
@@ -681,10 +691,7 @@ async fn send_keepalive_ping_if_due(
     Ok(())
 }
 
-async fn write_all_socket_async(
-    socket: &mut StackSocket,
-    mut buf: &[u8],
-) -> Result<(), NetError> {
+async fn write_all_socket_async(socket: &mut StackSocket, mut buf: &[u8]) -> Result<(), NetError> {
     while !buf.is_empty() {
         let written = socket.write(buf).await?;
         if written == 0 {
@@ -848,8 +855,7 @@ fn build_v5_will_props(will: &MqttWillConfig) -> Result<mqtt::packet::Properties
     }
     if let Some(response_topic) = &will.response_topic {
         props.push(mqtt::packet::Property::ResponseTopic(
-            mqtt::packet::ResponseTopic::new(response_topic.as_str())
-                .map_err(|e| e.to_string())?,
+            mqtt::packet::ResponseTopic::new(response_topic.as_str()).map_err(|e| e.to_string())?,
         ));
     }
     if let Some(correlation_data) = &will.correlation_data {
@@ -894,7 +900,9 @@ fn mqtt_meta_from_v5_publish(
 
     for prop in packet.props() {
         match prop {
-            mqtt::packet::Property::ContentType(prop) => content_type = Some(prop.val().to_string()),
+            mqtt::packet::Property::ContentType(prop) => {
+                content_type = Some(prop.val().to_string())
+            }
             mqtt::packet::Property::PayloadFormatIndicator(prop) => {
                 payload_format = Some(prop.val().to_string())
             }
@@ -941,7 +949,6 @@ fn mqtt_meta_from_v5_publish(
     }
 }
 
-
 pub(crate) fn routed_message_from_packet(
     pending_command_ids: &mut HashMap<u16, String>,
     pending_reply_routes: &mut HashMap<String, PendingReplyRoute>,
@@ -955,13 +962,9 @@ pub(crate) fn routed_message_from_packet(
         mqtt::packet::Packet::V3_1_1Publish(packet) => Some(RoutedMessage::Event(
             routed_event_from_v3_publish(device_id, &packet),
         )),
-        mqtt::packet::Packet::V5_0Puback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_puback(
-                pending_command_ids,
-                device_id,
-                &packet,
-            )))
-        }
+        mqtt::packet::Packet::V5_0Puback(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_puback(pending_command_ids, device_id, &packet),
+        )),
         mqtt::packet::Packet::V3_1_1Puback(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
@@ -971,20 +974,12 @@ pub(crate) fn routed_message_from_packet(
                 true,
             )))
         }
-            mqtt::packet::Packet::V5_0Pubrec(packet) => {
-                Some(RoutedMessage::Result(routed_result_from_v5_pubrec(
-                    pending_command_ids,
-                    device_id,
-                    &packet,
-                )))
-            }
-        mqtt::packet::Packet::V5_0Pubrel(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_pubrel(
-                pending_command_ids,
-                device_id,
-                &packet,
-            )))
-        }
+        mqtt::packet::Packet::V5_0Pubrec(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_pubrec(pending_command_ids, device_id, &packet),
+        )),
+        mqtt::packet::Packet::V5_0Pubrel(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_pubrel(pending_command_ids, device_id, &packet),
+        )),
         mqtt::packet::Packet::V3_1_1Pubrec(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
@@ -1003,13 +998,9 @@ pub(crate) fn routed_message_from_packet(
                 false,
             )))
         }
-        mqtt::packet::Packet::V5_0Pubcomp(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_pubcomp(
-                pending_command_ids,
-                device_id,
-                &packet,
-            )))
-        }
+        mqtt::packet::Packet::V5_0Pubcomp(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_pubcomp(pending_command_ids, device_id, &packet),
+        )),
         mqtt::packet::Packet::V3_1_1Pubcomp(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
@@ -1019,13 +1010,9 @@ pub(crate) fn routed_message_from_packet(
                 true,
             )))
         }
-        mqtt::packet::Packet::V5_0Suback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_suback(
-                pending_command_ids,
-                device_id,
-                &packet,
-            )))
-        }
+        mqtt::packet::Packet::V5_0Suback(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_suback(pending_command_ids, device_id, &packet),
+        )),
         mqtt::packet::Packet::V3_1_1Suback(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
@@ -1035,13 +1022,9 @@ pub(crate) fn routed_message_from_packet(
                 true,
             )))
         }
-        mqtt::packet::Packet::V5_0Unsuback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_unsuback(
-                pending_command_ids,
-                device_id,
-                &packet,
-            )))
-        }
+        mqtt::packet::Packet::V5_0Unsuback(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_unsuback(pending_command_ids, device_id, &packet),
+        )),
         mqtt::packet::Packet::V3_1_1Unsuback(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
@@ -1071,8 +1054,7 @@ fn pending_reply_route_from_packet(
             for prop in packet.props() {
                 match prop {
                     mqtt::packet::Property::CorrelationData(prop) => {
-                        correlation_key =
-                            Some(String::from_utf8_lossy(prop.val()).into_owned());
+                        correlation_key = Some(String::from_utf8_lossy(prop.val()).into_owned());
                     }
                     mqtt::packet::Property::ResponseTopic(prop) => {
                         reply_to = Some(Address::Channel(prop.val().to_string()));
@@ -1270,11 +1252,16 @@ fn routed_result_from_v5_puback(
                 DeliveryState::Rejected
             }
         }),
-        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        reason_code
+            .filter(|code| code.is_failure())
+            .map(|code| code.to_string()),
         true,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_code
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props_opt(packet.props()),
         ))),
     )
@@ -1297,11 +1284,16 @@ fn routed_result_from_v5_pubrec(
                 DeliveryState::Rejected
             }
         }),
-        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        reason_code
+            .filter(|code| code.is_failure())
+            .map(|code| code.to_string()),
         false,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_code
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props_opt(packet.props()),
         ))),
     )
@@ -1324,11 +1316,16 @@ fn routed_result_from_v5_pubrel(
                 DeliveryState::Rejected
             }
         }),
-        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        reason_code
+            .filter(|code| code.is_failure())
+            .map(|code| code.to_string()),
         false,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_code
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props_opt(packet.props()),
         ))),
     )
@@ -1351,11 +1348,16 @@ fn routed_result_from_v5_pubcomp(
                 DeliveryState::Rejected
             }
         }),
-        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        reason_code
+            .filter(|code| code.is_failure())
+            .map(|code| code.to_string()),
         true,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_code
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props_opt(packet.props()),
         ))),
     )
@@ -1389,7 +1391,10 @@ fn routed_result_from_v5_suback(
         true,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_codes.into_iter().map(|code| code.to_string()).collect(),
+            reason_codes
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props(packet.props()),
         ))),
     )
@@ -1423,7 +1428,10 @@ fn routed_result_from_v5_unsuback(
         true,
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
-            reason_codes.into_iter().map(|code| code.to_string()).collect(),
+            reason_codes
+                .into_iter()
+                .map(|code| code.to_string())
+                .collect(),
             reason_string_from_props(packet.props()),
         ))),
     )
@@ -1465,10 +1473,7 @@ fn routed_result_from_v5_disconnect(
     }
 }
 
-fn routed_result_from_v5_auth(
-    device_id: &str,
-    packet: &mqtt::packet::v5_0::Auth,
-) -> RoutedResult {
+fn routed_result_from_v5_auth(device_id: &str, packet: &mqtt::packet::v5_0::Auth) -> RoutedResult {
     let reason_code = packet.reason_code();
     let reason_code_text = reason_code.map(|code| code.to_string());
     let state = reason_code.map_or(DeliveryState::Accepted, |code| {

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -11,7 +11,11 @@ use runtime_stack::StackSocket;
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
 
+use crate::convert::qos_from_delivery;
 use crate::types::{MqttPacketRequest, MqttWirePacket};
+use crate::{
+    MqttAuthChallenge, MqttAuthFlowReason, MqttAuthProvider, MqttAuthResponse, MqttAuthStage,
+};
 #[cfg(feature = "tokio-runtime")]
 use crate::runtime_stack;
 #[cfg(feature = "async-std-runtime")]
@@ -29,6 +33,7 @@ pub(crate) struct MqttClientSession {
     pub(crate) awaiting_pingresp: bool,
     pub(crate) pending_command_ids: HashMap<u16, String>,
     pub(crate) pending_reply_routes: HashMap<String, PendingReplyRoute>,
+    pub(crate) authentication_method: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -69,7 +74,11 @@ pub(crate) fn build_connect_packet(
     match config.preferred_protocol_version() {
         MqttProtocolVersion::V5_0 => {
             let mut props = mqtt::packet::Properties::new();
-            if let Some(session_expiry_secs) = config.session_expiry_secs {
+            if let Some(session_expiry_secs) = config
+                .connect_properties
+                .session_expiry_interval_secs
+                .or(config.session_expiry_secs)
+            {
                 props.push(mqtt::packet::Property::SessionExpiryInterval(
                     mqtt::packet::SessionExpiryInterval::new(session_expiry_secs)
                         .map_err(|e| e.to_string())?,
@@ -135,6 +144,18 @@ pub(crate) fn build_connect_packet(
                 .clean_start(config.clean_start)
                 .keep_alive(config.keepalive_secs.unwrap_or(0))
                 .props(props);
+            if let Some(will) = &config.will {
+                builder = builder
+                    .will_message(
+                        will.topic.as_str(),
+                        will.payload.clone(),
+                        qos_from_delivery(will.delivery),
+                        will.retain,
+                    )
+                    .map_err(|e| e.to_string())?;
+                let will_props = build_v5_will_props(will)?;
+                builder = builder.will_props(will_props);
+            }
             if let Some(auth) = &config.auth {
                 if let Some(username) = &auth.username {
                     builder = builder
@@ -220,7 +241,7 @@ pub(crate) async fn send_packet_request_async(
     let events = session
         .connection
         .checked_send(packet_request_into_packet(request));
-    let _ = handle_connection_events_async(runtime, session, device_id, None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, device_id, None, None, events).await?;
     Ok(())
 }
 
@@ -336,6 +357,7 @@ pub(crate) async fn read_from_session_async(
     session: &mut MqttClientSession,
     device_id: &str,
     negotiated_connack: Option<&Shared<RuntimeMutex<Option<MqttConnackProperties>>>>,
+    auth_handler: Option<&Shared<RuntimeMutex<Option<Shared<dyn MqttAuthProvider>>>>>,
     timeout: Option<Duration>,
 ) -> Result<Vec<RoutedMessage>, String> {
     session
@@ -351,7 +373,15 @@ pub(crate) async fn read_from_session_async(
             session.awaiting_pingresp = false;
             let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
             let events = session.connection.recv(&mut cursor);
-            handle_connection_events_async(runtime, session, device_id, negotiated_connack, events).await
+            handle_connection_events_async(
+                runtime,
+                session,
+                device_id,
+                negotiated_connack,
+                auth_handler,
+                events,
+            )
+            .await
         }
         Err(NetError::TimedOut) => {
             send_keepalive_ping_if_due(runtime, session, device_id).await?;
@@ -366,6 +396,7 @@ pub(crate) async fn handle_connection_events_async(
     session: &mut MqttClientSession,
     device_id: &str,
     negotiated_connack: Option<&Shared<RuntimeMutex<Option<MqttConnackProperties>>>>,
+    auth_handler: Option<&Shared<RuntimeMutex<Option<Shared<dyn MqttAuthProvider>>>>>,
     events: Vec<mqtt::connection::Event>,
 ) -> Result<Vec<RoutedMessage>, String> {
     let mut routed = Vec::new();
@@ -387,6 +418,9 @@ pub(crate) async fn handle_connection_events_async(
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
                 if let Some(negotiated_connack) = negotiated_connack {
                     update_negotiated_connack(negotiated_connack, &packet).await?;
+                }
+                if let Some(auth_handler) = auth_handler {
+                    process_incoming_auth_async(runtime, session, auth_handler, &packet).await?;
                 }
                 if let Some(message) = routed_message_from_packet(
                     &mut session.pending_command_ids,
@@ -412,6 +446,175 @@ pub(crate) async fn handle_connection_events_async(
     Ok(routed)
 }
 
+async fn process_incoming_auth_async(
+    runtime: &runtime_stack::StackRuntime,
+    session: &mut MqttClientSession,
+    auth_handler: &Shared<RuntimeMutex<Option<Shared<dyn MqttAuthProvider>>>>,
+    packet: &mqtt::packet::Packet,
+) -> Result<(), String> {
+    let challenge = match packet {
+        mqtt::packet::Packet::V5_0Auth(packet) => Some(auth_challenge_from_auth(session, packet)?),
+        _ => None,
+    };
+    let Some(challenge) = challenge else {
+        return Ok(());
+    };
+
+    let handler = auth_handler
+        .lock()
+        .await
+        .map_err(|_| "failed to lock MQTT auth handler".to_string())?
+        .clone();
+    let Some(handler) = handler else {
+        return Err("mqtt broker requested enhanced authentication but no auth handler is configured".to_string());
+    };
+    let Some(response) = handler.respond(challenge)? else {
+        return Err("mqtt auth handler returned no response for broker challenge".to_string());
+    };
+    let packet = build_auth_packet(session, response)?;
+    let events = session.connection.checked_send(packet);
+    process_outbound_auth_events_async(runtime, session, events).await?;
+    Ok(())
+}
+
+async fn process_outbound_auth_events_async(
+    runtime: &runtime_stack::StackRuntime,
+    session: &mut MqttClientSession,
+    events: Vec<mqtt::connection::Event>,
+) -> Result<(), String> {
+    for event in events {
+        match event {
+            mqtt::connection::Event::RequestSendPacket { packet, .. } => {
+                let bytes = packet.to_continuous_buffer();
+                write_all_socket_async(&mut session.stream, &bytes)
+                    .await
+                    .map_err(|e| format!("failed to write MQTT auth packet: {e:?}"))?;
+                session
+                    .stream
+                    .flush()
+                    .await
+                    .map_err(|e| format!("failed to flush MQTT auth packet: {e:?}"))?;
+                session.last_activity = runtime.now();
+            }
+            mqtt::connection::Event::NotifyError(error) => {
+                return Err(format!("mqtt protocol error during auth exchange: {error:?}"));
+            }
+            mqtt::connection::Event::RequestClose => {
+                return Err("mqtt auth exchange requested close".to_string());
+            }
+            mqtt::connection::Event::NotifyPacketReceived(_)
+            | mqtt::connection::Event::NotifyPacketIdReleased(_)
+            | mqtt::connection::Event::RequestTimerReset { .. }
+            | mqtt::connection::Event::RequestTimerCancel(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn auth_challenge_from_auth(
+    session: &mut MqttClientSession,
+    packet: &mqtt::packet::v5_0::Auth,
+) -> Result<MqttAuthChallenge, String> {
+    let mut authentication_method = session.authentication_method.clone();
+    let mut authentication_data = None;
+    let mut reason_string = None;
+    let mut user_properties = Vec::new();
+
+    if let Some(props) = packet.props() {
+        for prop in props {
+            match prop {
+                mqtt::packet::Property::AuthenticationMethod(prop) => {
+                    authentication_method = Some(prop.val().to_string());
+                }
+                mqtt::packet::Property::AuthenticationData(prop) => {
+                    authentication_data = Some(prop.val().to_vec());
+                }
+                mqtt::packet::Property::ReasonString(prop) => {
+                    reason_string = Some(prop.val().to_string());
+                }
+                mqtt::packet::Property::UserProperty(prop) => {
+                    user_properties.push((prop.key().to_string(), prop.val().to_string()));
+                }
+                _ => {}
+            }
+        }
+    }
+    session.authentication_method = authentication_method.clone();
+
+    Ok(MqttAuthChallenge {
+        stage: if packet.reason_code() == Some(mqtt::result_code::AuthReasonCode::ReAuthenticate) {
+            MqttAuthStage::Reauthenticate
+        } else {
+            MqttAuthStage::Connect
+        },
+        reason: auth_flow_reason_from_v5(
+            packet
+                .reason_code()
+                .unwrap_or(mqtt::result_code::AuthReasonCode::Success),
+        ),
+        authentication_method,
+        authentication_data,
+        reason_string,
+        user_properties,
+    })
+}
+
+fn auth_flow_reason_from_v5(code: mqtt::result_code::AuthReasonCode) -> MqttAuthFlowReason {
+    match code {
+        mqtt::result_code::AuthReasonCode::Success => MqttAuthFlowReason::Success,
+        mqtt::result_code::AuthReasonCode::ContinueAuthentication => {
+            MqttAuthFlowReason::ContinueAuthentication
+        }
+        mqtt::result_code::AuthReasonCode::ReAuthenticate => MqttAuthFlowReason::ReAuthenticate,
+    }
+}
+
+fn build_auth_packet(
+    session: &mut MqttClientSession,
+    response: MqttAuthResponse,
+) -> Result<mqtt::packet::v5_0::Auth, String> {
+    let mut props = mqtt::packet::Properties::new();
+    let method = response
+        .authentication_method
+        .clone()
+        .or_else(|| session.authentication_method.clone());
+    if let Some(authentication_method) = &method {
+        props.push(mqtt::packet::Property::AuthenticationMethod(
+            mqtt::packet::AuthenticationMethod::new(authentication_method.as_str())
+                .map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(authentication_data) = response.authentication_data {
+        props.push(mqtt::packet::Property::AuthenticationData(
+            mqtt::packet::AuthenticationData::new(authentication_data).map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(reason_string) = &response.reason_string {
+        props.push(mqtt::packet::Property::ReasonString(
+            mqtt::packet::ReasonString::new(reason_string.as_str()).map_err(|e| e.to_string())?,
+        ));
+    }
+    for (key, value) in &response.user_properties {
+        props.push(mqtt::packet::Property::UserProperty(
+            mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
+                .map_err(|e| e.to_string())?,
+        ));
+    }
+    session.authentication_method = method;
+
+    mqtt::packet::v5_0::Auth::builder()
+        .reason_code(match response.reason {
+            MqttAuthFlowReason::Success => mqtt::result_code::AuthReasonCode::Success,
+            MqttAuthFlowReason::ContinueAuthentication => {
+                mqtt::result_code::AuthReasonCode::ContinueAuthentication
+            }
+            MqttAuthFlowReason::ReAuthenticate => mqtt::result_code::AuthReasonCode::ReAuthenticate,
+        })
+        .props(props)
+        .build()
+        .map_err(|e| e.to_string())
+}
+
 pub(crate) async fn disconnect_session(
     runtime: &runtime_stack::StackRuntime,
     session: &mut MqttClientSession,
@@ -432,7 +635,7 @@ pub(crate) async fn disconnect_session(
             session.connection.checked_send(disconnect)
         }
     };
-    let _ = handle_connection_events_async(runtime, session, "", None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, "", None, None, events).await?;
     session
         .stream
         .close()
@@ -474,7 +677,7 @@ async fn send_keepalive_ping_if_due(
         }
     };
     session.awaiting_pingresp = true;
-    let _ = handle_connection_events_async(runtime, session, device_id, None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, device_id, None, None, events).await?;
     Ok(())
 }
 
@@ -525,6 +728,7 @@ fn connack_snapshot_from_v5(
     let mut receive_maximum = None;
     let mut maximum_packet_size = None;
     let mut topic_alias_maximum = None;
+    let mut session_expiry_interval_secs = None;
     let mut maximum_qos = None;
     let mut retain_available = None;
     let mut server_keep_alive = None;
@@ -533,6 +737,7 @@ fn connack_snapshot_from_v5(
     let mut shared_subscription_available = None;
     let mut authentication_method = None;
     let mut authentication_data = None;
+    let mut reason_string = None;
     let mut user_properties = Vec::new();
 
     for prop in packet.props() {
@@ -554,6 +759,9 @@ fn connack_snapshot_from_v5(
             }
             mqtt::packet::Property::TopicAliasMaximum(prop) => {
                 topic_alias_maximum = Some(prop.val());
+            }
+            mqtt::packet::Property::SessionExpiryInterval(prop) => {
+                session_expiry_interval_secs = Some(prop.val());
             }
             mqtt::packet::Property::MaximumQos(prop) => {
                 maximum_qos = Some(prop.val());
@@ -579,6 +787,9 @@ fn connack_snapshot_from_v5(
             mqtt::packet::Property::AuthenticationData(prop) => {
                 authentication_data = Some(prop.val().to_vec());
             }
+            mqtt::packet::Property::ReasonString(prop) => {
+                reason_string = Some(prop.val().to_string());
+            }
             mqtt::packet::Property::UserProperty(prop) => {
                 user_properties.push((prop.key().to_string(), prop.val().to_string()));
             }
@@ -589,12 +800,14 @@ fn connack_snapshot_from_v5(
     Ok(MqttConnackProperties {
         session_present: packet.session_present(),
         reason_code: Some(packet.reason_code().to_string()),
+        reason_string,
         assigned_client_identifier,
         response_information,
         server_reference,
         receive_maximum,
         maximum_packet_size,
         topic_alias_maximum,
+        session_expiry_interval_secs,
         maximum_qos,
         retain_available,
         server_keep_alive,
@@ -605,6 +818,127 @@ fn connack_snapshot_from_v5(
         authentication_data,
         user_properties,
     })
+}
+
+fn build_v5_will_props(will: &MqttWillConfig) -> Result<mqtt::packet::Properties, String> {
+    let mut props = mqtt::packet::Properties::new();
+    if let Some(delay) = will.delay_interval_secs {
+        props.push(mqtt::packet::Property::WillDelayInterval(
+            mqtt::packet::WillDelayInterval::new(delay).map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(payload_format) = will.payload_format {
+        props.push(mqtt::packet::Property::PayloadFormatIndicator(
+            mqtt::packet::PayloadFormatIndicator::new(match payload_format {
+                MqttPayloadFormat::Bytes => mqtt::packet::PayloadFormat::Binary,
+                MqttPayloadFormat::Utf8 => mqtt::packet::PayloadFormat::String,
+            })
+            .map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(expiry) = will.message_expiry_interval_secs {
+        props.push(mqtt::packet::Property::MessageExpiryInterval(
+            mqtt::packet::MessageExpiryInterval::new(expiry).map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(content_type) = &will.content_type {
+        props.push(mqtt::packet::Property::ContentType(
+            mqtt::packet::ContentType::new(content_type.as_str()).map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(response_topic) = &will.response_topic {
+        props.push(mqtt::packet::Property::ResponseTopic(
+            mqtt::packet::ResponseTopic::new(response_topic.as_str())
+                .map_err(|e| e.to_string())?,
+        ));
+    }
+    if let Some(correlation_data) = &will.correlation_data {
+        props.push(mqtt::packet::Property::CorrelationData(
+            mqtt::packet::CorrelationData::new(correlation_data.clone())
+                .map_err(|e| e.to_string())?,
+        ));
+    }
+    for (key, value) in &will.user_properties {
+        props.push(mqtt::packet::Property::UserProperty(
+            mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
+                .map_err(|e| e.to_string())?,
+        ));
+    }
+    Ok(props)
+}
+
+fn reason_string_from_props(props: &mqtt::packet::Properties) -> Option<String> {
+    props.iter().find_map(|prop| match prop {
+        mqtt::packet::Property::ReasonString(prop) => Some(prop.val().to_string()),
+        _ => None,
+    })
+}
+
+fn reason_string_from_props_opt(props: &Option<mqtt::packet::Properties>) -> Option<String> {
+    props.as_ref().and_then(reason_string_from_props)
+}
+
+fn mqtt_meta_from_v5_publish(
+    packet: &mqtt::packet::v5_0::Publish,
+    correlation_override: Option<String>,
+) -> MqttMeta {
+    let mut content_type = None;
+    let mut payload_format = None;
+    let mut message_expiry_interval_secs = None;
+    let mut response_topic = None;
+    let mut correlation_data = correlation_override;
+    let mut correlation_data_bytes = None;
+    let mut topic_alias = None;
+    let mut subscription_identifiers = Vec::new();
+    let mut user_properties = Vec::new();
+
+    for prop in packet.props() {
+        match prop {
+            mqtt::packet::Property::ContentType(prop) => content_type = Some(prop.val().to_string()),
+            mqtt::packet::Property::PayloadFormatIndicator(prop) => {
+                payload_format = Some(prop.val().to_string())
+            }
+            mqtt::packet::Property::MessageExpiryInterval(prop) => {
+                message_expiry_interval_secs = Some(prop.val())
+            }
+            mqtt::packet::Property::ResponseTopic(prop) => {
+                response_topic = Some(prop.val().to_string())
+            }
+            mqtt::packet::Property::CorrelationData(prop) => {
+                if correlation_data.is_none() {
+                    correlation_data = Some(String::from_utf8_lossy(prop.val()).into_owned());
+                }
+                correlation_data_bytes = Some(prop.val().to_vec());
+            }
+            mqtt::packet::Property::TopicAlias(prop) => topic_alias = Some(prop.val()),
+            mqtt::packet::Property::SubscriptionIdentifier(prop) => {
+                subscription_identifiers.push(prop.val())
+            }
+            mqtt::packet::Property::UserProperty(prop) => {
+                user_properties.push((prop.key().to_string(), prop.val().to_string()))
+            }
+            _ => {}
+        }
+    }
+
+    MqttMeta {
+        topic: packet.topic_name().to_string(),
+        qos: packet.qos() as u8,
+        retain: packet.retain(),
+        duplicate: packet.dup(),
+        packet_id: packet.packet_id(),
+        content_type,
+        payload_format,
+        message_expiry_interval_secs,
+        response_topic,
+        correlation_data,
+        correlation_data_bytes,
+        topic_alias,
+        subscription_identifiers,
+        user_properties,
+        reason_codes: Vec::new(),
+        reason_string: None,
+    }
 }
 
 
@@ -637,14 +971,30 @@ pub(crate) fn routed_message_from_packet(
                 true,
             )))
         }
-        mqtt::packet::Packet::V5_0Pubrec(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_v5_pubrec(
+            mqtt::packet::Packet::V5_0Pubrec(packet) => {
+                Some(RoutedMessage::Result(routed_result_from_v5_pubrec(
+                    pending_command_ids,
+                    device_id,
+                    &packet,
+                )))
+            }
+        mqtt::packet::Packet::V5_0Pubrel(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_v5_pubrel(
                 pending_command_ids,
                 device_id,
                 &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Pubrec(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Dispatched,
+                false,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Pubrel(packet) => {
             Some(RoutedMessage::Result(routed_result_from_packet_id(
                 pending_command_ids,
                 device_id,
@@ -704,6 +1054,9 @@ pub(crate) fn routed_message_from_packet(
         mqtt::packet::Packet::V5_0Disconnect(packet) => Some(RoutedMessage::Result(
             routed_result_from_v5_disconnect(device_id, &packet),
         )),
+        mqtt::packet::Packet::V5_0Auth(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_auth(device_id, &packet),
+        )),
         _ => None,
     }
 }
@@ -754,13 +1107,18 @@ pub(crate) fn routed_event_from_v5_publish(
     packet: &mqtt::packet::v5_0::Publish,
 ) -> RoutedEvent {
     let mut correlation_id = None;
+    let mut correlation_data_bytes = None;
     let mut reply_to = None;
     let mut content_type = None;
+    let mut payload_format = None;
+    let mut message_expiry_interval_secs = None;
+    let mut topic_alias = None;
     let mut subscription_identifiers = Vec::new();
     let mut user_properties = Vec::new();
     for prop in packet.props() {
         match prop {
             mqtt::packet::Property::CorrelationData(prop) => {
+                correlation_data_bytes = Some(prop.val().to_vec());
                 correlation_id = Some(String::from_utf8_lossy(prop.val()).into_owned());
             }
             mqtt::packet::Property::ResponseTopic(prop) => {
@@ -768,6 +1126,15 @@ pub(crate) fn routed_event_from_v5_publish(
             }
             mqtt::packet::Property::ContentType(prop) => {
                 content_type = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::PayloadFormatIndicator(prop) => {
+                payload_format = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::MessageExpiryInterval(prop) => {
+                message_expiry_interval_secs = Some(prop.val());
+            }
+            mqtt::packet::Property::TopicAlias(prop) => {
+                topic_alias = Some(prop.val());
             }
             mqtt::packet::Property::SubscriptionIdentifier(prop) => {
                 subscription_identifiers.push(prop.val());
@@ -801,11 +1168,16 @@ pub(crate) fn routed_event_from_v5_publish(
             duplicate: packet.dup(),
             packet_id: packet.packet_id(),
             content_type,
+            payload_format,
+            message_expiry_interval_secs,
             response_topic,
             correlation_data: correlation_id.clone(),
+            correlation_data_bytes,
+            topic_alias,
             subscription_identifiers,
             user_properties,
             reason_codes: Vec::new(),
+            reason_string: None,
         })),
     }
 }
@@ -839,41 +1211,10 @@ fn routed_reply_or_event_from_v5_publish(
                     reply_to: route.reply_to,
                 }),
             },
-            transport: Some(TransportMeta::Mqtt(MqttMeta {
-                topic: packet.topic_name().to_string(),
-                qos: packet.qos() as u8,
-                retain: packet.retain(),
-                duplicate: packet.dup(),
-                packet_id: packet.packet_id(),
-                content_type: packet.props().iter().find_map(|prop| match prop {
-                    mqtt::packet::Property::ContentType(prop) => Some(prop.val().to_string()),
-                    _ => None,
-                }),
-                response_topic: packet.props().iter().find_map(|prop| match prop {
-                    mqtt::packet::Property::ResponseTopic(prop) => Some(prop.val().to_string()),
-                    _ => None,
-                }),
-                correlation_data: Some(correlation_key),
-                subscription_identifiers: packet
-                    .props()
-                    .iter()
-                    .filter_map(|prop| match prop {
-                        mqtt::packet::Property::SubscriptionIdentifier(prop) => Some(prop.val()),
-                        _ => None,
-                    })
-                    .collect(),
-                user_properties: packet
-                    .props()
-                    .iter()
-                    .filter_map(|prop| match prop {
-                        mqtt::packet::Property::UserProperty(prop) => {
-                            Some((prop.key().to_string(), prop.val().to_string()))
-                        }
-                        _ => None,
-                    })
-                    .collect(),
-                reason_codes: Vec::new(),
-            })),
+            transport: Some(TransportMeta::Mqtt(mqtt_meta_from_v5_publish(
+                packet,
+                Some(correlation_key),
+            ))),
         }));
     }
 
@@ -898,11 +1239,16 @@ pub(crate) fn routed_event_from_v3_publish(
             duplicate: packet.dup(),
             packet_id: packet.packet_id(),
             content_type: None,
+            payload_format: None,
+            message_expiry_interval_secs: None,
             response_topic: None,
             correlation_data: None,
+            correlation_data_bytes: None,
+            topic_alias: None,
             subscription_identifiers: Vec::new(),
             user_properties: Vec::new(),
             reason_codes: Vec::new(),
+            reason_string: None,
         })),
     }
 }
@@ -929,6 +1275,7 @@ fn routed_result_from_v5_puback(
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
             reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props_opt(packet.props()),
         ))),
     )
 }
@@ -955,6 +1302,34 @@ fn routed_result_from_v5_pubrec(
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
             reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props_opt(packet.props()),
+        ))),
+    )
+}
+
+fn routed_result_from_v5_pubrel(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Pubrel,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        reason_code.map_or(DeliveryState::Dispatched, |code| {
+            if code.is_success() {
+                DeliveryState::Dispatched
+            } else {
+                DeliveryState::Rejected
+            }
+        }),
+        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        false,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props_opt(packet.props()),
         ))),
     )
 }
@@ -981,6 +1356,7 @@ fn routed_result_from_v5_pubcomp(
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
             reason_code.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props_opt(packet.props()),
         ))),
     )
 }
@@ -1014,6 +1390,7 @@ fn routed_result_from_v5_suback(
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
             reason_codes.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props(packet.props()),
         ))),
     )
 }
@@ -1047,6 +1424,7 @@ fn routed_result_from_v5_unsuback(
         Some(TransportMeta::Mqtt(mqtt_result_meta(
             Some(packet.packet_id()),
             reason_codes.into_iter().map(|code| code.to_string()).collect(),
+            reason_string_from_props(packet.props()),
         ))),
     )
 }
@@ -1082,6 +1460,42 @@ fn routed_result_from_v5_disconnect(
         transport: Some(TransportMeta::Mqtt(mqtt_result_meta(
             None,
             reason_code_text.into_iter().collect(),
+            reason_string_from_props_opt(packet.props()),
+        ))),
+    }
+}
+
+fn routed_result_from_v5_auth(
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Auth,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    let reason_code_text = reason_code.map(|code| code.to_string());
+    let state = reason_code.map_or(DeliveryState::Accepted, |code| {
+        if code.is_success() {
+            DeliveryState::Accepted
+        } else {
+            DeliveryState::Rejected
+        }
+    });
+    RoutedResult {
+        source: mqtt_source(device_id),
+        result: CommandResult {
+            command_id: "__mqtt_auth__".to_string(),
+            device_id: device_id.to_string(),
+            state: state.clone(),
+            payload: None,
+            error: if state == DeliveryState::Rejected {
+                reason_code_text.clone()
+            } else {
+                None
+            },
+            correlation: None,
+        },
+        transport: Some(TransportMeta::Mqtt(mqtt_result_meta(
+            None,
+            reason_code_text.into_iter().collect(),
+            reason_string_from_props_opt(packet.props()),
         ))),
     }
 }
@@ -1089,6 +1503,7 @@ fn routed_result_from_v5_disconnect(
 fn mqtt_result_meta(
     packet_id: Option<u16>,
     reason_codes: Vec<String>,
+    reason_string: Option<String>,
 ) -> MqttMeta {
     MqttMeta {
         topic: String::new(),
@@ -1097,11 +1512,16 @@ fn mqtt_result_meta(
         duplicate: false,
         packet_id,
         content_type: None,
+        payload_format: None,
+        message_expiry_interval_secs: None,
         response_topic: None,
         correlation_data: None,
+        correlation_data_bytes: None,
+        topic_alias: None,
         subscription_identifiers: Vec::new(),
         user_properties: Vec::new(),
         reason_codes,
+        reason_string,
     }
 }
 

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -71,6 +71,60 @@ pub(crate) fn build_connect_packet(
                         .map_err(|e| e.to_string())?,
                 ));
             }
+            if let Some(receive_maximum) = config.connect_properties.receive_maximum {
+                props.push(mqtt::packet::Property::ReceiveMaximum(
+                    mqtt::packet::ReceiveMaximum::new(receive_maximum)
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(maximum_packet_size) = config.connect_properties.maximum_packet_size {
+                props.push(mqtt::packet::Property::MaximumPacketSize(
+                    mqtt::packet::MaximumPacketSize::new(maximum_packet_size)
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(topic_alias_maximum) = config.connect_properties.topic_alias_maximum {
+                props.push(mqtt::packet::Property::TopicAliasMaximum(
+                    mqtt::packet::TopicAliasMaximum::new(topic_alias_maximum)
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(request_problem_information) =
+                config.connect_properties.request_problem_information
+            {
+                props.push(mqtt::packet::Property::RequestProblemInformation(
+                    mqtt::packet::RequestProblemInformation::new(request_problem_information as u8)
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(request_response_information) =
+                config.connect_properties.request_response_information
+            {
+                props.push(mqtt::packet::Property::RequestResponseInformation(
+                    mqtt::packet::RequestResponseInformation::new(
+                        request_response_information as u8,
+                    )
+                    .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(authentication_method) = &config.connect_properties.authentication_method {
+                props.push(mqtt::packet::Property::AuthenticationMethod(
+                    mqtt::packet::AuthenticationMethod::new(authentication_method.as_str())
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            if let Some(authentication_data) = &config.connect_properties.authentication_data {
+                props.push(mqtt::packet::Property::AuthenticationData(
+                    mqtt::packet::AuthenticationData::new(authentication_data.clone())
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
+            for (key, value) in &config.connect_properties.user_properties {
+                props.push(mqtt::packet::Property::UserProperty(
+                    mqtt::packet::UserProperty::new(key.as_str(), value.as_str())
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
             let mut builder = mqtt::packet::v5_0::Connect::builder()
                 .client_id(config.client_id.as_str())
                 .map_err(|e| e.to_string())?
@@ -165,7 +219,7 @@ pub(crate) async fn send_packet_request_async(
     let events = session
         .connection
         .checked_send(packet_request_into_packet(request));
-    let _ = handle_connection_events_async(session, device_id, events).await?;
+    let _ = handle_connection_events_async(session, device_id, None, events).await?;
     Ok(())
 }
 
@@ -282,6 +336,7 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
 pub(crate) async fn read_from_session_async(
     session: &mut MqttClientSession,
     device_id: &str,
+    negotiated_connack: Option<&std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>>,
     timeout: Option<Duration>,
 ) -> Result<Vec<RoutedMessage>, String> {
     session
@@ -297,7 +352,7 @@ pub(crate) async fn read_from_session_async(
             session.awaiting_pingresp = false;
             let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
             let events = session.connection.recv(&mut cursor);
-            handle_connection_events_async(session, device_id, events).await
+            handle_connection_events_async(session, device_id, negotiated_connack, events).await
         }
         Err(NetError::TimedOut) => {
             send_keepalive_ping_if_due(session, device_id).await?;
@@ -311,6 +366,7 @@ pub(crate) async fn read_from_session_async(
 pub(crate) async fn handle_connection_events_async(
     session: &mut MqttClientSession,
     device_id: &str,
+    negotiated_connack: Option<&std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>>,
     events: Vec<mqtt::connection::Event>,
 ) -> Result<Vec<RoutedMessage>, String> {
     let mut routed = Vec::new();
@@ -330,6 +386,9 @@ pub(crate) async fn handle_connection_events_async(
                 session.last_activity = Instant::now();
             }
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
+                if let Some(negotiated_connack) = negotiated_connack {
+                    update_negotiated_connack(negotiated_connack, &packet)?;
+                }
                 if let Some(message) = routed_message_from_packet(
                     &mut session.pending_command_ids,
                     &mut session.pending_reply_routes,
@@ -372,7 +431,7 @@ pub(crate) async fn disconnect_session(session: &mut MqttClientSession) -> Resul
             session.connection.checked_send(disconnect)
         }
     };
-    let _ = handle_connection_events_async(session, "", events).await?;
+    let _ = handle_connection_events_async(session, "", None, events).await?;
     session
         .stream
         .close()
@@ -414,7 +473,7 @@ async fn send_keepalive_ping_if_due(
         }
     };
     session.awaiting_pingresp = true;
-    let _ = handle_connection_events_async(session, device_id, events).await?;
+    let _ = handle_connection_events_async(session, device_id, None, events).await?;
     Ok(())
 }
 
@@ -431,6 +490,122 @@ async fn write_all_socket_async(
         buf = &buf[written..];
     }
     Ok(())
+}
+
+#[cfg(feature = "std")]
+fn update_negotiated_connack(
+    negotiated_connack: &std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>,
+    packet: &mqtt::packet::Packet,
+) -> Result<(), String> {
+    let snapshot = match packet {
+        mqtt::packet::Packet::V5_0Connack(packet) => Some(connack_snapshot_from_v5(packet)?),
+        mqtt::packet::Packet::V3_1_1Connack(packet) => Some(MqttConnackProperties {
+            session_present: packet.session_present(),
+            reason_code: Some(packet.return_code().to_string()),
+            ..MqttConnackProperties::default()
+        }),
+        _ => None,
+    };
+
+    if let Some(snapshot) = snapshot {
+        let mut guard = negotiated_connack
+            .lock()
+            .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())?;
+        *guard = Some(snapshot);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "std")]
+fn connack_snapshot_from_v5(
+    packet: &mqtt::packet::v5_0::Connack,
+) -> Result<MqttConnackProperties, String> {
+    let mut assigned_client_identifier = None;
+    let mut response_information = None;
+    let mut server_reference = None;
+    let mut receive_maximum = None;
+    let mut maximum_packet_size = None;
+    let mut topic_alias_maximum = None;
+    let mut maximum_qos = None;
+    let mut retain_available = None;
+    let mut server_keep_alive = None;
+    let mut wildcard_subscription_available = None;
+    let mut subscription_identifier_available = None;
+    let mut shared_subscription_available = None;
+    let mut authentication_method = None;
+    let mut authentication_data = None;
+    let mut user_properties = Vec::new();
+
+    for prop in packet.props() {
+        match prop {
+            mqtt::packet::Property::AssignedClientIdentifier(prop) => {
+                assigned_client_identifier = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::ResponseInformation(prop) => {
+                response_information = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::ServerReference(prop) => {
+                server_reference = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::ReceiveMaximum(prop) => {
+                receive_maximum = Some(prop.val());
+            }
+            mqtt::packet::Property::MaximumPacketSize(prop) => {
+                maximum_packet_size = Some(prop.val());
+            }
+            mqtt::packet::Property::TopicAliasMaximum(prop) => {
+                topic_alias_maximum = Some(prop.val());
+            }
+            mqtt::packet::Property::MaximumQos(prop) => {
+                maximum_qos = Some(prop.val());
+            }
+            mqtt::packet::Property::RetainAvailable(prop) => {
+                retain_available = Some(prop.val() != 0);
+            }
+            mqtt::packet::Property::ServerKeepAlive(prop) => {
+                server_keep_alive = Some(prop.val());
+            }
+            mqtt::packet::Property::WildcardSubscriptionAvailable(prop) => {
+                wildcard_subscription_available = Some(prop.val() != 0);
+            }
+            mqtt::packet::Property::SubscriptionIdentifierAvailable(prop) => {
+                subscription_identifier_available = Some(prop.val() != 0);
+            }
+            mqtt::packet::Property::SharedSubscriptionAvailable(prop) => {
+                shared_subscription_available = Some(prop.val() != 0);
+            }
+            mqtt::packet::Property::AuthenticationMethod(prop) => {
+                authentication_method = Some(prop.val().to_string());
+            }
+            mqtt::packet::Property::AuthenticationData(prop) => {
+                authentication_data = Some(prop.val().to_vec());
+            }
+            mqtt::packet::Property::UserProperty(prop) => {
+                user_properties.push((prop.key().to_string(), prop.val().to_string()));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(MqttConnackProperties {
+        session_present: packet.session_present(),
+        reason_code: Some(packet.reason_code().to_string()),
+        assigned_client_identifier,
+        response_information,
+        server_reference,
+        receive_maximum,
+        maximum_packet_size,
+        topic_alias_maximum,
+        maximum_qos,
+        retain_available,
+        server_keep_alive,
+        wildcard_subscription_available,
+        subscription_identifier_available,
+        shared_subscription_available,
+        authentication_method,
+        authentication_data,
+        user_properties,
+    })
 }
 
 

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -1,13 +1,12 @@
-#[cfg(feature = "std")]
 use std::{
     collections::HashMap,
     string::String,
-    time::{Duration, Instant},
+    time::Duration,
     vec::Vec,
 };
 
 use ferredge_core::prelude::*;
-#[cfg(feature = "std")]
+use ferredge_core::prelude::RuntimeInstant as RuntimeInstantExt;
 use runtime_stack::StackSocket;
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
@@ -18,26 +17,26 @@ use crate::runtime_stack;
 #[cfg(feature = "async-std-runtime")]
 use crate::runtime_stack;
 
-#[cfg(feature = "std")]
+type RuntimeMutex<T> = <runtime_stack::StackRuntime as AsyncRuntime>::Mutex<T>;
+type StackInstant = <runtime_stack::StackRuntime as AsyncRuntime>::Instant;
+
 pub(crate) struct MqttClientSession {
     pub(crate) stream: StackSocket,
     pub(crate) connection: mqtt::Connection<mqtt::role::Client>,
     pub(crate) protocol_version: MqttProtocolVersion,
     pub(crate) keepalive_secs: Option<u16>,
-    pub(crate) last_activity: Instant,
+    pub(crate) last_activity: StackInstant,
     pub(crate) awaiting_pingresp: bool,
     pub(crate) pending_command_ids: HashMap<u16, String>,
     pub(crate) pending_reply_routes: HashMap<String, PendingReplyRoute>,
 }
 
-#[cfg(feature = "std")]
 #[derive(Debug, Clone)]
 pub(crate) struct PendingReplyRoute {
     pub(crate) command_id: String,
     pub(crate) reply_to: Option<Address>,
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn normalize_broker_addr(broker: &str) -> String {
     let without_scheme = broker
         .strip_prefix("mqtt://")
@@ -50,7 +49,6 @@ pub(crate) fn normalize_broker_addr(broker: &str) -> String {
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn mqtt_version_from_core(version: MqttProtocolVersion) -> mqtt::Version {
     match version {
         MqttProtocolVersion::V3_1_1 => mqtt::Version::V3_1_1,
@@ -58,7 +56,6 @@ pub(crate) fn mqtt_version_from_core(version: MqttProtocolVersion) -> mqtt::Vers
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn build_connect_packet(
     config: &MqttEndpointConfig,
 ) -> Result<mqtt::packet::Packet, String> {
@@ -168,7 +165,6 @@ pub(crate) fn build_connect_packet(
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn packet_request_into_packet(request: MqttPacketRequest) -> mqtt::packet::Packet {
     match request.packet {
         MqttWirePacket::V5Publish(packet) => packet.into(),
@@ -180,7 +176,6 @@ pub(crate) fn packet_request_into_packet(request: MqttPacketRequest) -> mqtt::pa
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
     match packet {
         MqttWirePacket::V5Publish(packet) => packet.packet_id(),
@@ -192,7 +187,6 @@ pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
     }
 }
 
-#[cfg(feature = "std")]
 fn publish_requires_packet_id(packet: &MqttWirePacket) -> bool {
     match packet {
         MqttWirePacket::V5Publish(packet) => packet.qos() != mqtt::packet::Qos::AtMostOnce,
@@ -201,8 +195,8 @@ fn publish_requires_packet_id(packet: &MqttWirePacket) -> bool {
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) async fn send_packet_request_async(
+    runtime: &runtime_stack::StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
     request: MqttPacketRequest,
@@ -219,11 +213,10 @@ pub(crate) async fn send_packet_request_async(
     let events = session
         .connection
         .checked_send(packet_request_into_packet(request));
-    let _ = handle_connection_events_async(session, device_id, None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, device_id, None, events).await?;
     Ok(())
 }
 
-#[cfg(feature = "std")]
 fn assign_runtime_packet_id(
     session: &mut MqttClientSession,
     request: MqttPacketRequest,
@@ -256,7 +249,6 @@ fn assign_runtime_packet_id(
     }
 }
 
-#[cfg(feature = "std")]
 fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<MqttPacketRequest, String> {
     let command_id = request.command_id;
     let packet = match request.packet {
@@ -332,11 +324,11 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
     Ok(MqttPacketRequest { command_id, packet })
 }
 
-#[cfg(feature = "std")]
 pub(crate) async fn read_from_session_async(
+    runtime: &runtime_stack::StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
-    negotiated_connack: Option<&std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>>,
+    negotiated_connack: Option<&Shared<RuntimeMutex<Option<MqttConnackProperties>>>>,
     timeout: Option<Duration>,
 ) -> Result<Vec<RoutedMessage>, String> {
     session
@@ -348,25 +340,25 @@ pub(crate) async fn read_from_session_async(
     match session.stream.read(&mut buffer).await {
         Ok(0) => Err("mqtt stream closed".to_string()),
         Ok(n) => {
-            session.last_activity = Instant::now();
+            session.last_activity = runtime.now();
             session.awaiting_pingresp = false;
             let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
             let events = session.connection.recv(&mut cursor);
-            handle_connection_events_async(session, device_id, negotiated_connack, events).await
+            handle_connection_events_async(runtime, session, device_id, negotiated_connack, events).await
         }
         Err(NetError::TimedOut) => {
-            send_keepalive_ping_if_due(session, device_id).await?;
+            send_keepalive_ping_if_due(runtime, session, device_id).await?;
             Ok(Vec::new())
         }
         Err(error) => Err(format!("failed reading MQTT stream: {error:?}")),
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) async fn handle_connection_events_async(
+    runtime: &runtime_stack::StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
-    negotiated_connack: Option<&std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>>,
+    negotiated_connack: Option<&Shared<RuntimeMutex<Option<MqttConnackProperties>>>>,
     events: Vec<mqtt::connection::Event>,
 ) -> Result<Vec<RoutedMessage>, String> {
     let mut routed = Vec::new();
@@ -383,11 +375,11 @@ pub(crate) async fn handle_connection_events_async(
                     .flush()
                     .await
                     .map_err(|e| format!("failed to flush MQTT packet: {e:?}"))?;
-                session.last_activity = Instant::now();
+                session.last_activity = runtime.now();
             }
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
                 if let Some(negotiated_connack) = negotiated_connack {
-                    update_negotiated_connack(negotiated_connack, &packet)?;
+                    update_negotiated_connack(negotiated_connack, &packet).await?;
                 }
                 if let Some(message) = routed_message_from_packet(
                     &mut session.pending_command_ids,
@@ -413,8 +405,10 @@ pub(crate) async fn handle_connection_events_async(
     Ok(routed)
 }
 
-#[cfg(feature = "std")]
-pub(crate) async fn disconnect_session(session: &mut MqttClientSession) -> Result<(), String> {
+pub(crate) async fn disconnect_session(
+    runtime: &runtime_stack::StackRuntime,
+    session: &mut MqttClientSession,
+) -> Result<(), String> {
     let events = match session.protocol_version {
         MqttProtocolVersion::V5_0 => {
             let disconnect = mqtt::packet::v5_0::Disconnect::builder()
@@ -431,7 +425,7 @@ pub(crate) async fn disconnect_session(session: &mut MqttClientSession) -> Resul
             session.connection.checked_send(disconnect)
         }
     };
-    let _ = handle_connection_events_async(session, "", None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, "", None, events).await?;
     session
         .stream
         .close()
@@ -439,8 +433,8 @@ pub(crate) async fn disconnect_session(session: &mut MqttClientSession) -> Resul
         .map_err(|e| format!("failed to close MQTT socket: {e:?}"))
 }
 
-#[cfg(feature = "std")]
 async fn send_keepalive_ping_if_due(
+    runtime: &runtime_stack::StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
 ) -> Result<(), String> {
@@ -473,11 +467,10 @@ async fn send_keepalive_ping_if_due(
         }
     };
     session.awaiting_pingresp = true;
-    let _ = handle_connection_events_async(session, device_id, None, events).await?;
+    let _ = handle_connection_events_async(runtime, session, device_id, None, events).await?;
     Ok(())
 }
 
-#[cfg(feature = "std")]
 async fn write_all_socket_async(
     socket: &mut StackSocket,
     mut buf: &[u8],
@@ -492,9 +485,8 @@ async fn write_all_socket_async(
     Ok(())
 }
 
-#[cfg(feature = "std")]
-fn update_negotiated_connack(
-    negotiated_connack: &std::sync::Arc<std::sync::Mutex<Option<MqttConnackProperties>>>,
+async fn update_negotiated_connack(
+    negotiated_connack: &Shared<RuntimeMutex<Option<MqttConnackProperties>>>,
     packet: &mqtt::packet::Packet,
 ) -> Result<(), String> {
     let snapshot = match packet {
@@ -510,13 +502,13 @@ fn update_negotiated_connack(
     if let Some(snapshot) = snapshot {
         let mut guard = negotiated_connack
             .lock()
+            .await
             .map_err(|_| "failed to lock negotiated MQTT CONNACK state".to_string())?;
         *guard = Some(snapshot);
     }
     Ok(())
 }
 
-#[cfg(feature = "std")]
 fn connack_snapshot_from_v5(
     packet: &mqtt::packet::v5_0::Connack,
 ) -> Result<MqttConnackProperties, String> {
@@ -609,7 +601,6 @@ fn connack_snapshot_from_v5(
 }
 
 
-#[cfg(feature = "std")]
 pub(crate) fn routed_message_from_packet(
     pending_command_ids: &mut HashMap<u16, String>,
     pending_reply_routes: &mut HashMap<String, PendingReplyRoute>,
@@ -710,7 +701,6 @@ pub(crate) fn routed_message_from_packet(
     }
 }
 
-#[cfg(feature = "std")]
 fn pending_reply_route_from_packet(
     request: &MqttPacketRequest,
 ) -> Option<(String, PendingReplyRoute)> {
@@ -745,7 +735,6 @@ fn pending_reply_route_from_packet(
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn mqtt_source(device_id: &str) -> EndpointRef {
     EndpointRef {
         device_id: device_id.to_string(),
@@ -753,7 +742,6 @@ pub(crate) fn mqtt_source(device_id: &str) -> EndpointRef {
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn routed_event_from_v5_publish(
     device_id: &str,
     packet: &mqtt::packet::v5_0::Publish,
@@ -815,7 +803,6 @@ pub(crate) fn routed_event_from_v5_publish(
     }
 }
 
-#[cfg(feature = "std")]
 fn routed_reply_or_event_from_v5_publish(
     pending_reply_routes: &mut HashMap<String, PendingReplyRoute>,
     device_id: &str,
@@ -888,7 +875,6 @@ fn routed_reply_or_event_from_v5_publish(
     )))
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn routed_event_from_v3_publish(
     device_id: &str,
     packet: &mqtt::packet::v3_1_1::Publish,
@@ -914,7 +900,6 @@ pub(crate) fn routed_event_from_v3_publish(
     }
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_puback(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -941,7 +926,6 @@ fn routed_result_from_v5_puback(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_pubrec(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -968,7 +952,6 @@ fn routed_result_from_v5_pubrec(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_pubcomp(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -995,7 +978,6 @@ fn routed_result_from_v5_pubcomp(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_suback(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -1029,7 +1011,6 @@ fn routed_result_from_v5_suback(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_unsuback(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -1063,7 +1044,6 @@ fn routed_result_from_v5_unsuback(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_v5_disconnect(
     device_id: &str,
     packet: &mqtt::packet::v5_0::Disconnect,
@@ -1099,7 +1079,6 @@ fn routed_result_from_v5_disconnect(
     }
 }
 
-#[cfg(feature = "std")]
 fn mqtt_result_meta(
     packet_id: Option<u16>,
     reason_codes: Vec<String>,
@@ -1119,7 +1098,6 @@ fn mqtt_result_meta(
     }
 }
 
-#[cfg(feature = "std")]
 pub(crate) fn routed_result_from_packet_id(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,
@@ -1138,7 +1116,6 @@ pub(crate) fn routed_result_from_packet_id(
     )
 }
 
-#[cfg(feature = "std")]
 fn routed_result_from_packet_id_with_transport(
     pending_command_ids: &mut HashMap<u16, String>,
     device_id: &str,

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -2,7 +2,7 @@
 use std::{
     collections::HashMap,
     string::String,
-    time::Duration,
+    time::{Duration, Instant},
     vec::Vec,
 };
 
@@ -22,6 +22,10 @@ use crate::runtime_stack;
 pub(crate) struct MqttClientSession {
     pub(crate) stream: StackSocket,
     pub(crate) connection: mqtt::Connection<mqtt::role::Client>,
+    pub(crate) protocol_version: MqttProtocolVersion,
+    pub(crate) keepalive_secs: Option<u16>,
+    pub(crate) last_activity: Instant,
+    pub(crate) awaiting_pingresp: bool,
     pub(crate) pending_command_ids: HashMap<u16, String>,
     pub(crate) pending_reply_routes: HashMap<String, PendingReplyRoute>,
 }
@@ -60,11 +64,19 @@ pub(crate) fn build_connect_packet(
 ) -> Result<mqtt::packet::Packet, String> {
     match config.preferred_protocol_version() {
         MqttProtocolVersion::V5_0 => {
+            let mut props = mqtt::packet::Properties::new();
+            if let Some(session_expiry_secs) = config.session_expiry_secs {
+                props.push(mqtt::packet::Property::SessionExpiryInterval(
+                    mqtt::packet::SessionExpiryInterval::new(session_expiry_secs)
+                        .map_err(|e| e.to_string())?,
+                ));
+            }
             let mut builder = mqtt::packet::v5_0::Connect::builder()
                 .client_id(config.client_id.as_str())
                 .map_err(|e| e.to_string())?
                 .clean_start(config.clean_start)
-                .keep_alive(config.keepalive_secs.unwrap_or(0));
+                .keep_alive(config.keepalive_secs.unwrap_or(0))
+                .props(props);
             if let Some(auth) = &config.auth {
                 if let Some(username) = &auth.username {
                     builder = builder
@@ -297,13 +309,18 @@ pub(crate) async fn read_from_session_async(
 
     let mut buffer = [0u8; 4096];
     match session.stream.read(&mut buffer).await {
-        Ok(0) => Ok(Vec::new()),
+        Ok(0) => Err("mqtt stream closed".to_string()),
         Ok(n) => {
+            session.last_activity = Instant::now();
+            session.awaiting_pingresp = false;
             let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
             let events = session.connection.recv(&mut cursor);
             handle_connection_events_async(session, device_id, events).await
         }
-        Err(NetError::TimedOut) => Ok(Vec::new()),
+        Err(NetError::TimedOut) => {
+            send_keepalive_ping_if_due(session, device_id).await?;
+            Ok(Vec::new())
+        }
         Err(error) => Err(format!("failed reading MQTT stream: {error:?}")),
     }
 }
@@ -338,6 +355,7 @@ pub(crate) async fn handle_connection_events_async(
                     .flush()
                     .await
                     .map_err(|e| format!("failed to flush MQTT packet: {e:?}"))?;
+                session.last_activity = Instant::now();
             }
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
                 if let Some(message) = routed_message_from_packet(
@@ -362,6 +380,70 @@ pub(crate) async fn handle_connection_events_async(
     }
 
     Ok(routed)
+}
+
+#[cfg(feature = "std")]
+pub(crate) async fn disconnect_session(session: &mut MqttClientSession) -> Result<(), String> {
+    let events = match session.protocol_version {
+        MqttProtocolVersion::V5_0 => {
+            let disconnect = mqtt::packet::v5_0::Disconnect::builder()
+            .reason_code(mqtt::result_code::DisconnectReasonCode::NormalDisconnection)
+            .props(mqtt::packet::Properties::new())
+            .build()
+            .map_err(|e| e.to_string())?;
+            session.connection.checked_send(disconnect)
+        }
+        MqttProtocolVersion::V3_1_1 => {
+            let disconnect = mqtt::packet::v3_1_1::Disconnect::builder()
+            .build()
+            .map_err(|e| e.to_string())?;
+            session.connection.checked_send(disconnect)
+        }
+    };
+    let _ = handle_connection_events_async(session, "", events).await?;
+    session
+        .stream
+        .close()
+        .await
+        .map_err(|e| format!("failed to close MQTT socket: {e:?}"))
+}
+
+#[cfg(feature = "std")]
+async fn send_keepalive_ping_if_due(
+    session: &mut MqttClientSession,
+    device_id: &str,
+) -> Result<(), String> {
+    let Some(keepalive_secs) = session.keepalive_secs else {
+        return Ok(());
+    };
+    if keepalive_secs == 0 {
+        return Ok(());
+    }
+
+    if session.last_activity.elapsed() < Duration::from_secs(keepalive_secs as u64) {
+        return Ok(());
+    }
+    if session.awaiting_pingresp {
+        return Err("mqtt keepalive timed out waiting for ping response".to_string());
+    }
+
+    let events = match session.protocol_version {
+        MqttProtocolVersion::V5_0 => {
+            let pingreq = mqtt::packet::v5_0::Pingreq::builder()
+            .build()
+            .map_err(|e| e.to_string())?;
+            session.connection.checked_send(pingreq)
+        }
+        MqttProtocolVersion::V3_1_1 => {
+            let pingreq = mqtt::packet::v3_1_1::Pingreq::builder()
+            .build()
+            .map_err(|e| e.to_string())?;
+            session.connection.checked_send(pingreq)
+        }
+    };
+    session.awaiting_pingresp = true;
+    let _ = handle_connection_events_async(session, device_id, events).await?;
+    Ok(())
 }
 
 #[cfg(feature = "std")]

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -42,6 +42,13 @@ pub(crate) fn normalize_broker_addr(broker: &str) -> String {
         .strip_prefix("mqtt://")
         .or_else(|| broker.strip_prefix("tcp://"))
         .unwrap_or(broker);
+    if without_scheme.starts_with('[') {
+        return if without_scheme.contains("]:") {
+            without_scheme.to_string()
+        } else {
+            format!("{without_scheme}:1883")
+        };
+    }
     if without_scheme.contains(':') {
         without_scheme.to_string()
     } else {

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -449,12 +449,10 @@ pub(crate) fn routed_message_from_packet(
             routed_event_from_v3_publish(device_id, &packet),
         )),
         mqtt::packet::Packet::V5_0Puback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_packet_id(
+            Some(RoutedMessage::Result(routed_result_from_v5_puback(
                 pending_command_ids,
                 device_id,
-                packet.packet_id(),
-                DeliveryState::Completed,
-                true,
+                &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Puback(packet) => {
@@ -467,12 +465,10 @@ pub(crate) fn routed_message_from_packet(
             )))
         }
         mqtt::packet::Packet::V5_0Pubrec(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_packet_id(
+            Some(RoutedMessage::Result(routed_result_from_v5_pubrec(
                 pending_command_ids,
                 device_id,
-                packet.packet_id(),
-                DeliveryState::Dispatched,
-                false,
+                &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Pubrec(packet) => {
@@ -485,12 +481,10 @@ pub(crate) fn routed_message_from_packet(
             )))
         }
         mqtt::packet::Packet::V5_0Pubcomp(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_packet_id(
+            Some(RoutedMessage::Result(routed_result_from_v5_pubcomp(
                 pending_command_ids,
                 device_id,
-                packet.packet_id(),
-                DeliveryState::Completed,
-                true,
+                &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Pubcomp(packet) => {
@@ -503,12 +497,10 @@ pub(crate) fn routed_message_from_packet(
             )))
         }
         mqtt::packet::Packet::V5_0Suback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_packet_id(
+            Some(RoutedMessage::Result(routed_result_from_v5_suback(
                 pending_command_ids,
                 device_id,
-                packet.packet_id(),
-                DeliveryState::Completed,
-                true,
+                &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Suback(packet) => {
@@ -521,12 +513,10 @@ pub(crate) fn routed_message_from_packet(
             )))
         }
         mqtt::packet::Packet::V5_0Unsuback(packet) => {
-            Some(RoutedMessage::Result(routed_result_from_packet_id(
+            Some(RoutedMessage::Result(routed_result_from_v5_unsuback(
                 pending_command_ids,
                 device_id,
-                packet.packet_id(),
-                DeliveryState::Completed,
-                true,
+                &packet,
             )))
         }
         mqtt::packet::Packet::V3_1_1Unsuback(packet) => {
@@ -538,6 +528,9 @@ pub(crate) fn routed_message_from_packet(
                 true,
             )))
         }
+        mqtt::packet::Packet::V5_0Disconnect(packet) => Some(RoutedMessage::Result(
+            routed_result_from_v5_disconnect(device_id, &packet),
+        )),
         _ => None,
     }
 }
@@ -642,6 +635,7 @@ pub(crate) fn routed_event_from_v5_publish(
             correlation_data: correlation_id.clone(),
             subscription_identifiers,
             user_properties,
+            reason_codes: Vec::new(),
         })),
     }
 }
@@ -709,6 +703,7 @@ fn routed_reply_or_event_from_v5_publish(
                         _ => None,
                     })
                     .collect(),
+                reason_codes: Vec::new(),
             })),
         }));
     }
@@ -739,7 +734,213 @@ pub(crate) fn routed_event_from_v3_publish(
             correlation_data: None,
             subscription_identifiers: Vec::new(),
             user_properties: Vec::new(),
+            reason_codes: Vec::new(),
         })),
+    }
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_puback(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Puback,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        reason_code.map_or(DeliveryState::Completed, |code| {
+            if code.is_success() {
+                DeliveryState::Completed
+            } else {
+                DeliveryState::Rejected
+            }
+        }),
+        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        true,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_code.into_iter().map(|code| code.to_string()).collect(),
+        ))),
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_pubrec(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Pubrec,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        reason_code.map_or(DeliveryState::Dispatched, |code| {
+            if code.is_success() {
+                DeliveryState::Dispatched
+            } else {
+                DeliveryState::Rejected
+            }
+        }),
+        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        false,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_code.into_iter().map(|code| code.to_string()).collect(),
+        ))),
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_pubcomp(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Pubcomp,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        reason_code.map_or(DeliveryState::Completed, |code| {
+            if code.is_success() {
+                DeliveryState::Completed
+            } else {
+                DeliveryState::Rejected
+            }
+        }),
+        reason_code.filter(|code| code.is_failure()).map(|code| code.to_string()),
+        true,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_code.into_iter().map(|code| code.to_string()).collect(),
+        ))),
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_suback(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Suback,
+) -> RoutedResult {
+    let reason_codes = packet.reason_codes();
+    let failed_codes: Vec<String> = reason_codes
+        .iter()
+        .filter(|code| code.is_failure())
+        .map(ToString::to_string)
+        .collect();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        if failed_codes.is_empty() {
+            DeliveryState::Completed
+        } else {
+            DeliveryState::Rejected
+        },
+        if failed_codes.is_empty() {
+            None
+        } else {
+            Some(failed_codes.join(","))
+        },
+        true,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_codes.into_iter().map(|code| code.to_string()).collect(),
+        ))),
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_unsuback(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Unsuback,
+) -> RoutedResult {
+    let reason_codes = packet.reason_codes();
+    let failed_codes: Vec<String> = reason_codes
+        .iter()
+        .filter(|code| code.is_failure())
+        .map(ToString::to_string)
+        .collect();
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet.packet_id(),
+        if failed_codes.is_empty() {
+            DeliveryState::Completed
+        } else {
+            DeliveryState::Rejected
+        },
+        if failed_codes.is_empty() {
+            None
+        } else {
+            Some(failed_codes.join(","))
+        },
+        true,
+        Some(TransportMeta::Mqtt(mqtt_result_meta(
+            Some(packet.packet_id()),
+            reason_codes.into_iter().map(|code| code.to_string()).collect(),
+        ))),
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_v5_disconnect(
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Disconnect,
+) -> RoutedResult {
+    let reason_code = packet.reason_code();
+    let reason_code_text = reason_code.map(|code| code.to_string());
+    let state = match reason_code {
+        None
+        | Some(mqtt::result_code::DisconnectReasonCode::NormalDisconnection)
+        | Some(mqtt::result_code::DisconnectReasonCode::DisconnectWithWillMessage) => {
+            DeliveryState::Completed
+        }
+        Some(_) => DeliveryState::Rejected,
+    };
+    RoutedResult {
+        source: mqtt_source(device_id),
+        result: CommandResult {
+            command_id: "__mqtt_disconnect__".to_string(),
+            device_id: device_id.to_string(),
+            state: state.clone(),
+            payload: None,
+            error: if state == DeliveryState::Rejected {
+                reason_code_text.clone()
+            } else {
+                None
+            },
+            correlation: None,
+        },
+        transport: Some(TransportMeta::Mqtt(mqtt_result_meta(
+            None,
+            reason_code_text.into_iter().collect(),
+        ))),
+    }
+}
+
+#[cfg(feature = "std")]
+fn mqtt_result_meta(
+    packet_id: Option<u16>,
+    reason_codes: Vec<String>,
+) -> MqttMeta {
+    MqttMeta {
+        topic: String::new(),
+        qos: 0,
+        retain: false,
+        duplicate: false,
+        packet_id,
+        content_type: None,
+        response_topic: None,
+        correlation_data: None,
+        subscription_identifiers: Vec::new(),
+        user_properties: Vec::new(),
+        reason_codes,
     }
 }
 
@@ -750,6 +951,27 @@ pub(crate) fn routed_result_from_packet_id(
     packet_id: u16,
     state: DeliveryState,
     remove: bool,
+) -> RoutedResult {
+    routed_result_from_packet_id_with_transport(
+        pending_command_ids,
+        device_id,
+        packet_id,
+        state,
+        None,
+        remove,
+        None,
+    )
+}
+
+#[cfg(feature = "std")]
+fn routed_result_from_packet_id_with_transport(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet_id: u16,
+    state: DeliveryState,
+    error: Option<String>,
+    remove: bool,
+    transport: Option<TransportMeta>,
 ) -> RoutedResult {
     let command_id = if remove {
         pending_command_ids
@@ -768,9 +990,9 @@ pub(crate) fn routed_result_from_packet_id(
             device_id: device_id.to_string(),
             state,
             payload: None,
-            error: None,
+            error,
             correlation: None,
         },
-        transport: None,
+        transport,
     }
 }

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -1,0 +1,531 @@
+#[cfg(feature = "std")]
+use std::{
+    collections::HashMap,
+    io::{ErrorKind, Read, Write},
+    net::TcpStream,
+    string::String,
+    time::Duration,
+    vec::Vec,
+};
+
+use ferredge_core::prelude::*;
+use mqtt_protocol_core::mqtt;
+use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
+
+use crate::types::{MqttPacketRequest, MqttWirePacket};
+
+#[cfg(feature = "std")]
+pub(crate) struct MqttClientSession {
+    pub(crate) stream: TcpStream,
+    pub(crate) connection: mqtt::Connection<mqtt::role::Client>,
+    pub(crate) pending_command_ids: HashMap<u16, String>,
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn normalize_broker_addr(broker: &str) -> String {
+    let without_scheme = broker
+        .strip_prefix("mqtt://")
+        .or_else(|| broker.strip_prefix("tcp://"))
+        .unwrap_or(broker);
+    if without_scheme.contains(':') {
+        without_scheme.to_string()
+    } else {
+        format!("{without_scheme}:1883")
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn mqtt_version_from_core(version: MqttProtocolVersion) -> mqtt::Version {
+    match version {
+        MqttProtocolVersion::V3_1_1 => mqtt::Version::V3_1_1,
+        MqttProtocolVersion::V5_0 => mqtt::Version::V5_0,
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn build_connect_packet(
+    config: &MqttEndpointConfig,
+) -> Result<mqtt::packet::Packet, String> {
+    match config.preferred_protocol_version() {
+        MqttProtocolVersion::V5_0 => {
+            let mut builder = mqtt::packet::v5_0::Connect::builder()
+                .client_id(config.client_id.as_str())
+                .map_err(|e| e.to_string())?
+                .clean_start(config.clean_start)
+                .keep_alive(config.keepalive_secs.unwrap_or(0));
+            if let Some(auth) = &config.auth {
+                if let Some(username) = &auth.username {
+                    builder = builder
+                        .user_name(username.as_str())
+                        .map_err(|e| e.to_string())?;
+                }
+                if let Some(password) = &auth.password {
+                    builder = builder
+                        .password(password.as_bytes().to_vec())
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            builder.build().map(Into::into).map_err(|e| e.to_string())
+        }
+        MqttProtocolVersion::V3_1_1 => {
+            let mut builder = mqtt::packet::v3_1_1::Connect::builder()
+                .client_id(config.client_id.as_str())
+                .map_err(|e| e.to_string())?
+                .clean_start(config.clean_start)
+                .keep_alive(config.keepalive_secs.unwrap_or(0));
+            if let Some(auth) = &config.auth {
+                if let Some(username) = &auth.username {
+                    builder = builder
+                        .user_name(username.as_str())
+                        .map_err(|e| e.to_string())?;
+                }
+                if let Some(password) = &auth.password {
+                    builder = builder
+                        .password(password.as_bytes().to_vec())
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            builder.build().map(Into::into).map_err(|e| e.to_string())
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn packet_request_into_packet(request: MqttPacketRequest) -> mqtt::packet::Packet {
+    match request.packet {
+        MqttWirePacket::V5Publish(packet) => packet.into(),
+        MqttWirePacket::V3Publish(packet) => packet.into(),
+        MqttWirePacket::V5Subscribe(packet) => packet.into(),
+        MqttWirePacket::V3Subscribe(packet) => packet.into(),
+        MqttWirePacket::V5Unsubscribe(packet) => packet.into(),
+        MqttWirePacket::V3Unsubscribe(packet) => packet.into(),
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
+    match packet {
+        MqttWirePacket::V5Publish(packet) => packet.packet_id(),
+        MqttWirePacket::V3Publish(packet) => packet.packet_id(),
+        MqttWirePacket::V5Subscribe(packet) => Some(packet.packet_id()),
+        MqttWirePacket::V3Subscribe(packet) => Some(packet.packet_id()),
+        MqttWirePacket::V5Unsubscribe(packet) => Some(packet.packet_id()),
+        MqttWirePacket::V3Unsubscribe(packet) => Some(packet.packet_id()),
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn send_packet_request(
+    session: &mut MqttClientSession,
+    device_id: &str,
+    request: MqttPacketRequest,
+) -> Result<(), String> {
+    let request = assign_runtime_packet_id(session, request)?;
+    if let Some(packet_id) = packet_request_packet_id(&request.packet) {
+        session
+            .pending_command_ids
+            .insert(packet_id, request.command_id.clone());
+    }
+    let events = session
+        .connection
+        .checked_send(packet_request_into_packet(request));
+    let _ = handle_connection_events(session, device_id, events)?;
+    Ok(())
+}
+
+#[cfg(feature = "std")]
+fn assign_runtime_packet_id(
+    session: &mut MqttClientSession,
+    request: MqttPacketRequest,
+) -> Result<MqttPacketRequest, String> {
+    let maybe_packet_id = match &request.packet {
+        MqttWirePacket::V5Publish(packet) if packet.qos() != mqtt::packet::Qos::AtMostOnce => {
+            if packet.packet_id().is_some() {
+                None
+            } else {
+                Some(
+                    session
+                        .connection
+                        .acquire_packet_id()
+                        .map_err(|e| e.to_string())?,
+                )
+            }
+        }
+        MqttWirePacket::V3Publish(packet) if packet.qos() != mqtt::packet::Qos::AtMostOnce => {
+            if packet.packet_id().is_some() {
+                None
+            } else {
+                Some(
+                    session
+                        .connection
+                        .acquire_packet_id()
+                        .map_err(|e| e.to_string())?,
+                )
+            }
+        }
+        MqttWirePacket::V5Subscribe(_)
+        | MqttWirePacket::V3Subscribe(_)
+        | MqttWirePacket::V5Unsubscribe(_)
+        | MqttWirePacket::V3Unsubscribe(_) => Some(
+            session
+                .connection
+                .acquire_packet_id()
+                .map_err(|e| e.to_string())?,
+        ),
+        _ => None,
+    };
+
+    if let Some(packet_id) = maybe_packet_id {
+        rebuild_with_packet_id(request, packet_id)
+    } else {
+        Ok(request)
+    }
+}
+
+#[cfg(feature = "std")]
+fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<MqttPacketRequest, String> {
+    let command_id = request.command_id;
+    let packet = match request.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            let rebuilt = mqtt::packet::v5_0::Publish::builder()
+                .topic_name(packet.topic_name())
+                .map_err(|e| e.to_string())?
+                .qos(packet.qos())
+                .retain(packet.retain())
+                .dup(packet.dup())
+                .packet_id(packet_id)
+                .payload(packet.payload().as_slice().to_vec())
+                .props(packet.props().clone())
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V5Publish(rebuilt)
+        }
+        MqttWirePacket::V3Publish(packet) => {
+            let rebuilt = mqtt::packet::v3_1_1::Publish::builder()
+                .topic_name(packet.topic_name())
+                .map_err(|e| e.to_string())?
+                .qos(packet.qos())
+                .retain(packet.retain())
+                .dup(packet.dup())
+                .packet_id(packet_id)
+                .payload(packet.payload().as_slice().to_vec())
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V3Publish(rebuilt)
+        }
+        MqttWirePacket::V5Subscribe(packet) => {
+            let rebuilt = mqtt::packet::v5_0::Subscribe::builder()
+                .packet_id(packet_id)
+                .entries(packet.entries().to_vec())
+                .props(packet.props().clone())
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V5Subscribe(rebuilt)
+        }
+        MqttWirePacket::V3Subscribe(packet) => {
+            let rebuilt = mqtt::packet::v3_1_1::Subscribe::builder()
+                .packet_id(packet_id)
+                .entries(packet.entries().to_vec())
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V3Subscribe(rebuilt)
+        }
+        MqttWirePacket::V5Unsubscribe(packet) => {
+            let entries: Vec<String> = packet.entries().iter().map(|entry| entry.as_str().to_string()).collect();
+            let entry_refs: Vec<&str> = entries.iter().map(String::as_str).collect();
+            let rebuilt = mqtt::packet::v5_0::Unsubscribe::builder()
+                .packet_id(packet_id)
+                .entries(entry_refs)
+                .map_err(|e| e.to_string())?
+                .props(packet.props().clone())
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V5Unsubscribe(rebuilt)
+        }
+        MqttWirePacket::V3Unsubscribe(packet) => {
+            let entries: Vec<String> = packet.entries().iter().map(|entry| entry.as_str().to_string()).collect();
+            let entry_refs: Vec<&str> = entries.iter().map(String::as_str).collect();
+            let rebuilt = mqtt::packet::v3_1_1::Unsubscribe::builder()
+                .packet_id(packet_id)
+                .entries(entry_refs)
+                .map_err(|e| e.to_string())?
+                .build()
+                .map_err(|e| e.to_string())?;
+            MqttWirePacket::V3Unsubscribe(rebuilt)
+        }
+    };
+
+    Ok(MqttPacketRequest { command_id, packet })
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn read_from_session(
+    session: &mut MqttClientSession,
+    device_id: &str,
+    timeout: Option<Duration>,
+) -> Result<Vec<RoutedMessage>, String> {
+    session
+        .stream
+        .set_read_timeout(timeout)
+        .map_err(|e| format!("failed to set MQTT read timeout: {e}"))?;
+
+    let mut buffer = [0u8; 4096];
+    match session.stream.read(&mut buffer) {
+        Ok(0) => Ok(Vec::new()),
+        Ok(n) => {
+            let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
+            let events = session.connection.recv(&mut cursor);
+            handle_connection_events(session, device_id, events)
+        }
+        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+            Ok(Vec::new())
+        }
+        Err(error) => Err(format!("failed reading MQTT stream: {error}")),
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn handle_connection_events(
+    session: &mut MqttClientSession,
+    device_id: &str,
+    events: Vec<mqtt::connection::Event>,
+) -> Result<Vec<RoutedMessage>, String> {
+    let mut routed = Vec::new();
+
+    for event in events {
+        match event {
+            mqtt::connection::Event::RequestSendPacket { packet, .. } => {
+                let bytes = packet.to_continuous_buffer();
+                session
+                    .stream
+                    .write_all(&bytes)
+                    .map_err(|e| format!("failed to write MQTT packet: {e}"))?;
+            }
+            mqtt::connection::Event::NotifyPacketReceived(packet) => {
+                if let Some(message) =
+                    routed_message_from_packet(&mut session.pending_command_ids, device_id, packet)
+                {
+                    routed.push(message);
+                }
+            }
+            mqtt::connection::Event::NotifyError(error) => {
+                return Err(format!("mqtt protocol error: {error:?}"));
+            }
+            mqtt::connection::Event::RequestClose => {
+                return Err("mqtt connection requested close".to_string());
+            }
+            mqtt::connection::Event::NotifyPacketIdReleased(_)
+            | mqtt::connection::Event::RequestTimerReset { .. }
+            | mqtt::connection::Event::RequestTimerCancel(_) => {}
+        }
+    }
+
+    Ok(routed)
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn routed_message_from_packet(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet: mqtt::packet::Packet,
+) -> Option<RoutedMessage> {
+    match packet {
+        mqtt::packet::Packet::V5_0Publish(packet) => Some(RoutedMessage::Event(
+            routed_event_from_v5_publish(device_id, &packet),
+        )),
+        mqtt::packet::Packet::V3_1_1Publish(packet) => Some(RoutedMessage::Event(
+            routed_event_from_v3_publish(device_id, &packet),
+        )),
+        mqtt::packet::Packet::V5_0Puback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Puback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V5_0Pubrec(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Dispatched,
+                false,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Pubrec(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Dispatched,
+                false,
+            )))
+        }
+        mqtt::packet::Packet::V5_0Pubcomp(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Pubcomp(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V5_0Suback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Suback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V5_0Unsuback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        mqtt::packet::Packet::V3_1_1Unsuback(packet) => {
+            Some(RoutedMessage::Result(routed_result_from_packet_id(
+                pending_command_ids,
+                device_id,
+                packet.packet_id(),
+                DeliveryState::Completed,
+                true,
+            )))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn mqtt_source(device_id: &str) -> EndpointRef {
+    EndpointRef {
+        device_id: device_id.to_string(),
+        protocol: DeviceProtocol::MQTT,
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn routed_event_from_v5_publish(
+    device_id: &str,
+    packet: &mqtt::packet::v5_0::Publish,
+) -> RoutedEvent {
+    let mut correlation_id = None;
+    let mut reply_to = None;
+    for prop in packet.props() {
+        match prop {
+            mqtt::packet::Property::CorrelationData(prop) => {
+                correlation_id = Some(String::from_utf8_lossy(prop.val()).into_owned());
+            }
+            mqtt::packet::Property::ResponseTopic(prop) => {
+                reply_to = Some(Address::Channel(prop.val().to_string()));
+            }
+            _ => {}
+        }
+    }
+    RoutedEvent {
+        source: mqtt_source(device_id),
+        address: Address::Channel(packet.topic_name().to_string()),
+        payload: packet.payload().as_slice().to_vec(),
+        correlation: if correlation_id.is_some() || reply_to.is_some() {
+            Some(Correlation {
+                request_id: correlation_id.unwrap_or_default(),
+                reply_to,
+            })
+        } else {
+            None
+        },
+        transport: Some(TransportMeta::Mqtt(MqttMeta {
+            topic: packet.topic_name().to_string(),
+            qos: packet.qos() as u8,
+            retain: packet.retain(),
+            duplicate: packet.dup(),
+            packet_id: packet.packet_id(),
+        })),
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn routed_event_from_v3_publish(
+    device_id: &str,
+    packet: &mqtt::packet::v3_1_1::Publish,
+) -> RoutedEvent {
+    RoutedEvent {
+        source: mqtt_source(device_id),
+        address: Address::Channel(packet.topic_name().to_string()),
+        payload: packet.payload().as_slice().to_vec(),
+        correlation: None,
+        transport: Some(TransportMeta::Mqtt(MqttMeta {
+            topic: packet.topic_name().to_string(),
+            qos: packet.qos() as u8,
+            retain: packet.retain(),
+            duplicate: packet.dup(),
+            packet_id: packet.packet_id(),
+        })),
+    }
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn routed_result_from_packet_id(
+    pending_command_ids: &mut HashMap<u16, String>,
+    device_id: &str,
+    packet_id: u16,
+    state: DeliveryState,
+    remove: bool,
+) -> RoutedResult {
+    let command_id = if remove {
+        pending_command_ids
+            .remove(&packet_id)
+            .unwrap_or_else(|| packet_id.to_string())
+    } else {
+        pending_command_ids
+            .get(&packet_id)
+            .cloned()
+            .unwrap_or_else(|| packet_id.to_string())
+    };
+    RoutedResult {
+        source: mqtt_source(device_id),
+        result: CommandResult {
+            command_id,
+            device_id: device_id.to_string(),
+            state,
+            payload: None,
+            error: None,
+            correlation: None,
+        },
+        transport: None,
+    }
+}

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -139,6 +139,15 @@ pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
 }
 
 #[cfg(feature = "std")]
+fn publish_requires_packet_id(packet: &MqttWirePacket) -> bool {
+    match packet {
+        MqttWirePacket::V5Publish(packet) => packet.qos() != mqtt::packet::Qos::AtMostOnce,
+        MqttWirePacket::V3Publish(packet) => packet.qos() != mqtt::packet::Qos::AtMostOnce,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "std")]
 pub(crate) async fn send_packet_request_async(
     session: &mut MqttClientSession,
     device_id: &str,
@@ -166,29 +175,13 @@ fn assign_runtime_packet_id(
     request: MqttPacketRequest,
 ) -> Result<MqttPacketRequest, String> {
     let maybe_packet_id = match &request.packet {
-        MqttWirePacket::V5Publish(packet) if packet.qos() != mqtt::packet::Qos::AtMostOnce => {
-            if packet.packet_id().is_some() {
-                None
-            } else {
-                Some(
-                    session
-                        .connection
-                        .acquire_packet_id()
-                        .map_err(|e| e.to_string())?,
-                )
-            }
-        }
-        MqttWirePacket::V3Publish(packet) if packet.qos() != mqtt::packet::Qos::AtMostOnce => {
-            if packet.packet_id().is_some() {
-                None
-            } else {
-                Some(
-                    session
-                        .connection
-                        .acquire_packet_id()
-                        .map_err(|e| e.to_string())?,
-                )
-            }
+        packet if publish_requires_packet_id(packet) => {
+            Some(
+                session
+                    .connection
+                    .acquire_packet_id()
+                    .map_err(|e| e.to_string())?,
+            )
         }
         MqttWirePacket::V5Subscribe(_)
         | MqttWirePacket::V3Subscribe(_)

--- a/crates/ferredge-proto-mqtt/src/runtime.rs
+++ b/crates/ferredge-proto-mqtt/src/runtime.rs
@@ -1,22 +1,26 @@
 #[cfg(feature = "std")]
 use std::{
     collections::HashMap,
-    io::{ErrorKind, Read, Write},
-    net::TcpStream,
     string::String,
     time::Duration,
     vec::Vec,
 };
 
 use ferredge_core::prelude::*;
+#[cfg(feature = "std")]
+use runtime_stack::{StackRuntime, StackSocket};
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
 
 use crate::types::{MqttPacketRequest, MqttWirePacket};
+#[cfg(feature = "tokio-runtime")]
+use crate::runtime_stack;
+#[cfg(feature = "async-std-runtime")]
+use crate::runtime_stack;
 
 #[cfg(feature = "std")]
 pub(crate) struct MqttClientSession {
-    pub(crate) stream: TcpStream,
+    pub(crate) stream: StackSocket,
     pub(crate) connection: mqtt::Connection<mqtt::role::Client>,
     pub(crate) pending_command_ids: HashMap<u16, String>,
     pub(crate) pending_reply_routes: HashMap<String, PendingReplyRoute>,
@@ -124,6 +128,7 @@ pub(crate) fn packet_request_packet_id(packet: &MqttWirePacket) -> Option<u16> {
 
 #[cfg(feature = "std")]
 pub(crate) fn send_packet_request(
+    runtime: &StackRuntime,
     session: &mut MqttClientSession,
     device_id: &str,
     request: MqttPacketRequest,
@@ -140,7 +145,7 @@ pub(crate) fn send_packet_request(
     let events = session
         .connection
         .checked_send(packet_request_into_packet(request));
-    let _ = handle_connection_events(session, device_id, events)?;
+    let _ = handle_connection_events(runtime, session, device_id, events)?;
     Ok(())
 }
 
@@ -271,6 +276,16 @@ fn rebuild_with_packet_id(request: MqttPacketRequest, packet_id: u16) -> Result<
 
 #[cfg(feature = "std")]
 pub(crate) fn read_from_session(
+    runtime: &StackRuntime,
+    session: &mut MqttClientSession,
+    device_id: &str,
+    timeout: Option<Duration>,
+) -> Result<Vec<RoutedMessage>, String> {
+    runtime.block_on(read_from_session_async(session, device_id, timeout))
+}
+
+#[cfg(feature = "std")]
+pub(crate) async fn read_from_session_async(
     session: &mut MqttClientSession,
     device_id: &str,
     timeout: Option<Duration>,
@@ -278,25 +293,33 @@ pub(crate) fn read_from_session(
     session
         .stream
         .set_read_timeout(timeout)
-        .map_err(|e| format!("failed to set MQTT read timeout: {e}"))?;
+        .map_err(|e| format!("failed to set MQTT read timeout: {e:?}"))?;
 
     let mut buffer = [0u8; 4096];
-    match session.stream.read(&mut buffer) {
+    match session.stream.read(&mut buffer).await {
         Ok(0) => Ok(Vec::new()),
         Ok(n) => {
             let mut cursor = mqtt::common::Cursor::new(&buffer[..n]);
             let events = session.connection.recv(&mut cursor);
-            handle_connection_events(session, device_id, events)
+            handle_connection_events_async(session, device_id, events).await
         }
-        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
-            Ok(Vec::new())
-        }
-        Err(error) => Err(format!("failed reading MQTT stream: {error}")),
+        Err(NetError::TimedOut) => Ok(Vec::new()),
+        Err(error) => Err(format!("failed reading MQTT stream: {error:?}")),
     }
 }
 
 #[cfg(feature = "std")]
 pub(crate) fn handle_connection_events(
+    runtime: &StackRuntime,
+    session: &mut MqttClientSession,
+    device_id: &str,
+    events: Vec<mqtt::connection::Event>,
+) -> Result<Vec<RoutedMessage>, String> {
+    runtime.block_on(handle_connection_events_async(session, device_id, events))
+}
+
+#[cfg(feature = "std")]
+pub(crate) async fn handle_connection_events_async(
     session: &mut MqttClientSession,
     device_id: &str,
     events: Vec<mqtt::connection::Event>,
@@ -307,10 +330,14 @@ pub(crate) fn handle_connection_events(
         match event {
             mqtt::connection::Event::RequestSendPacket { packet, .. } => {
                 let bytes = packet.to_continuous_buffer();
+                write_all_socket_async(&mut session.stream, &bytes)
+                    .await
+                    .map_err(|e| format!("failed to write MQTT packet: {e:?}"))?;
                 session
                     .stream
-                    .write_all(&bytes)
-                    .map_err(|e| format!("failed to write MQTT packet: {e}"))?;
+                    .flush()
+                    .await
+                    .map_err(|e| format!("failed to flush MQTT packet: {e:?}"))?;
             }
             mqtt::connection::Event::NotifyPacketReceived(packet) => {
                 if let Some(message) = routed_message_from_packet(
@@ -336,6 +363,22 @@ pub(crate) fn handle_connection_events(
 
     Ok(routed)
 }
+
+#[cfg(feature = "std")]
+async fn write_all_socket_async(
+    socket: &mut StackSocket,
+    mut buf: &[u8],
+) -> Result<(), NetError> {
+    while !buf.is_empty() {
+        let written = socket.write(buf).await?;
+        if written == 0 {
+            return Err(NetError::Closed);
+        }
+        buf = &buf[written..];
+    }
+    Ok(())
+}
+
 
 #[cfg(feature = "std")]
 pub(crate) fn routed_message_from_packet(

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -3,21 +3,23 @@ use std::{
     future::Future,
     io::{Read, Write},
     net::TcpListener,
-    sync::mpsc,
+    sync::{Arc, Mutex, mpsc},
     task::{Context, Poll, Waker},
     thread,
     time::Duration,
 };
 
 use ferredge_core::prelude::{
-    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions, EventSink,
-    EventSource, Correlation, Device, DeviceEndpoint, DeviceStatus, Lifecycle, Map,
-    MqttEndpointConfig, MqttProtocolVersion, RoutedEvent, RoutedMessage, TransportMeta,
+    ActionEmitter, Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
+    BrokerSubscriptionOptions, Command, Correlation, Device, DeviceEndpoint, DeviceStatus,
+    EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle, Map, MqttEndpointConfig,
+    MqttProtocolVersion, ProtocolBridge, RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
 };
 use mqtt_protocol_core::mqtt;
+use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
 
 use crate::{
-    runtime::routed_message_from_packet,
+    runtime::{build_connect_packet, routed_message_from_packet},
     types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
     MqttDriver, MqttListenerStatus,
 };
@@ -140,6 +142,118 @@ fn spawn_test_broker_v5_with_publishes(
     (format!("mqtt://{addr}"), shutdown_tx, handle)
 }
 
+fn spawn_reconnecting_test_broker_v5(
+    publish_after_reconnect: mqtt::packet::v5_0::Publish,
+) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
+    let addr = listener.local_addr().expect("test broker should have local addr");
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        for connection_idx in 0..2 {
+            let (mut stream, _) = listener.accept().expect("broker should accept client");
+            stream
+                .set_read_timeout(Some(Duration::from_millis(100)))
+                .expect("broker should set read timeout");
+
+            let mut connect_buffer = [0u8; 4096];
+            let _ = stream.read(&mut connect_buffer);
+
+            let connack = mqtt::packet::v5_0::Connack::builder()
+                .session_present(false)
+                .reason_code(mqtt::result_code::ConnectReasonCode::Success)
+                .props(Vec::new())
+                .build()
+                .expect("connack should build");
+            stream
+                .write_all(&connack.to_continuous_buffer())
+                .expect("broker should send connack");
+
+            if connection_idx == 0 {
+                continue;
+            }
+
+            thread::sleep(Duration::from_millis(150));
+            stream
+                .write_all(&publish_after_reconnect.to_continuous_buffer())
+                .expect("broker should send publish after reconnect");
+
+            loop {
+                if shutdown_rx.try_recv().is_ok() {
+                    break;
+                }
+                let mut buffer = [0u8; 4096];
+                match stream.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(_) => {}
+                    Err(error)
+                        if matches!(
+                            error.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) => {}
+                    Err(_) => break,
+                }
+            }
+        }
+    });
+
+    (format!("mqtt://{addr}"), shutdown_tx, handle)
+}
+
+fn spawn_keepalive_test_broker_v5() -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
+    let addr = listener.local_addr().expect("test broker should have local addr");
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("broker should accept client");
+        stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("broker should set read timeout");
+
+        let mut connect_buffer = [0u8; 4096];
+        let _ = stream.read(&mut connect_buffer);
+
+        let connack = mqtt::packet::v5_0::Connack::builder()
+            .session_present(false)
+            .reason_code(mqtt::result_code::ConnectReasonCode::Success)
+            .props(Vec::new())
+            .build()
+            .expect("connack should build");
+        stream
+            .write_all(&connack.to_continuous_buffer())
+            .expect("broker should send connack");
+
+        loop {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+            let mut buffer = [0u8; 4096];
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if buffer[..n].starts_with(&[0xC0, 0x00]) {
+                        let pingresp = mqtt::packet::v5_0::Pingresp::builder()
+                            .build()
+                            .expect("pingresp should build");
+                        stream
+                            .write_all(&pingresp.to_continuous_buffer())
+                            .expect("broker should send pingresp");
+                    }
+                }
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    (format!("mqtt://{addr}"), shutdown_tx, handle)
+}
+
 struct NoopSink;
 
 impl EventSink for NoopSink {
@@ -159,6 +273,120 @@ impl EventSink for FailOnEventSink {
 
     fn handle(&mut self, _event: Self::Event) -> Result<(), Self::Error> {
         Err(())
+    }
+}
+
+struct RecordingSink {
+    events: Arc<Mutex<Vec<RoutedEvent>>>,
+}
+
+impl EventSink for RecordingSink {
+    type Event = RoutedEvent;
+    type Error = ();
+
+    fn handle(&mut self, event: Self::Event) -> Result<(), Self::Error> {
+        self.events.lock().expect("recording sink lock").push(event);
+        Ok(())
+    }
+}
+
+struct CollectEmitter(Vec<RoutedMessage>);
+
+impl ActionEmitter for CollectEmitter {
+    type Error = ();
+
+    fn emit(&mut self, action: RoutedMessage) -> Result<(), Self::Error> {
+        self.0.push(action);
+        Ok(())
+    }
+}
+
+struct TestBridge;
+
+impl ProtocolBridge for TestBridge {
+    type Error = ();
+
+    async fn bridge_command<E>(&self, command: &Command, emitter: &mut E) -> Result<(), Self::Error>
+    where
+        E: ActionEmitter + Send,
+    {
+        if let Intent::Read { resource } = &command.intent {
+            emitter.emit(RoutedMessage::Command(Command {
+                id: format!("{}-mqtt", command.id),
+                source_device_id: Some(command.target_device_id.clone()),
+                target_device_id: "mqtt-device-1".to_string(),
+                intent: Intent::Send {
+                    channel: BrokerAddress {
+                        name: format!("requests/{resource}"),
+                        kind: Some(BrokerChannelKind::Topic),
+                    },
+                    payload: Vec::new(),
+                    options: BrokerMessageOptions::default(),
+                },
+                correlation: command.correlation.clone(),
+            })).map_err(|_| ())?;
+        }
+        Ok(())
+    }
+
+    async fn bridge_event<E>(&self, event: &RoutedEvent, emitter: &mut E) -> Result<(), Self::Error>
+    where
+        E: ActionEmitter + Send,
+    {
+        if let Address::Channel(channel) = &event.address
+            && channel == "sensors/temp"
+        {
+            emitter.emit(RoutedMessage::Command(Command {
+                id: "bridge-http-write".to_string(),
+                source_device_id: Some(event.source.device_id.clone()),
+                target_device_id: "http-device-1".to_string(),
+                intent: Intent::Write {
+                    resource: "setpoint".to_string(),
+                    payload: event.payload.clone(),
+                },
+                correlation: event.correlation.clone(),
+            })).map_err(|_| ())?;
+        }
+        Ok(())
+    }
+
+    async fn bridge_result<E>(&self, result: &RoutedResult, emitter: &mut E) -> Result<(), Self::Error>
+    where
+        E: ActionEmitter + Send,
+    {
+        emitter.emit(RoutedMessage::Result(result.clone())).map_err(|_| ())
+    }
+}
+
+fn make_http_driver() -> HttpDriver {
+    let mut resources = Map::default();
+    resources.insert(
+        "setpoint".to_string(),
+        ferredge_core::prelude::DeviceResource {
+            name: "setpoint".to_string(),
+            resource_attributes: HttpResourceAttributes {
+                slug: "/api/setpoint".to_string(),
+                method: "POST".to_string(),
+                headers: Some(vec![("Content-Type".to_string(), "text/plain".to_string())]),
+            },
+            unit: Some("C".to_string()),
+            permission: None,
+        },
+    );
+
+    HttpDriver {
+        dvc: Device {
+            id: "http-device-1".to_string(),
+            name: "HTTP Device".to_string(),
+            status: DeviceStatus::Online,
+            endpoint: DeviceEndpoint::http(HttpEndpointConfig {
+                url: "127.0.0.1:8080".to_string(),
+            }),
+            metadata: None,
+            max_connections: Some(4),
+            resources,
+            message_endpoints: Vec::new(),
+        },
     }
 }
 
@@ -661,6 +889,171 @@ fn mqtt_listener_reports_failed_when_sink_rejects_event() {
 
     block_on(driver.stop()).expect("driver should stop after failure");
 
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn bridge_can_translate_mqtt_event_into_http_request() {
+    let bridge = TestBridge;
+    let http = make_http_driver();
+    let mut emitter = CollectEmitter(Vec::new());
+    let event = RoutedEvent {
+        source: ferredge_core::prelude::EndpointRef {
+            device_id: "mqtt-device-1".to_string(),
+            protocol: ferredge_core::prelude::DeviceProtocol::MQTT,
+        },
+        address: Address::Channel("sensors/temp".to_string()),
+        payload: b"21".to_vec(),
+        correlation: None,
+        transport: None,
+    };
+
+    block_on(bridge.bridge_event(&event, &mut emitter)).expect("bridge should succeed");
+    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command") else {
+        panic!("expected bridged command");
+    };
+    let request = HttpRequest::try_from(HttpCommandRef {
+        device: &http.dvc,
+        command: &command,
+    })
+    .expect("bridged command should convert to http request");
+
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.path, "/api/setpoint");
+    assert_eq!(request.body, Some(b"21".to_vec()));
+}
+
+#[test]
+fn bridge_can_translate_http_command_into_mqtt_publish() {
+    let bridge = TestBridge;
+    let mqtt = make_default_driver();
+    let mut emitter = CollectEmitter(Vec::new());
+    let command = Command {
+        id: "http-read-1".to_string(),
+        source_device_id: Some("http-device-1".to_string()),
+        target_device_id: "http-device-1".to_string(),
+        intent: Intent::Read {
+            resource: "temp".to_string(),
+        },
+        correlation: None,
+    };
+
+    block_on(bridge.bridge_command(&command, &mut emitter)).expect("bridge should succeed");
+    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command") else {
+        panic!("expected bridged command");
+    };
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &mqtt.dvc,
+        command: &command,
+    })
+    .expect("bridged command should convert to mqtt packet");
+
+    match packet.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            assert_eq!(packet.topic_name(), "requests/temp");
+        }
+        other => panic!("expected v5 publish packet, got {other:?}"),
+    }
+}
+
+#[test]
+fn mqtt_connect_packet_maps_v5_session_expiry() {
+    let packet = build_connect_packet(&MqttEndpointConfig {
+        broker: "mqtt://broker".to_string(),
+        client_id: "client-1".to_string(),
+        auth: None,
+        tls: None,
+        keepalive_secs: Some(30),
+        clean_start: true,
+        session_expiry_secs: Some(3600),
+        topic_prefix: None,
+        supported_versions: vec![MqttProtocolVersion::V5_0],
+    })
+    .expect("connect packet should build");
+
+    let mqtt::packet::Packet::V5_0Connect(packet) = packet else {
+        panic!("expected v5 connect packet");
+    };
+    let saw_session_expiry = packet.props().iter().any(|prop| matches!(
+        prop,
+        mqtt::packet::Property::SessionExpiryInterval(value) if value.val() == 3600
+    ));
+    assert!(saw_session_expiry);
+}
+
+#[test]
+fn mqtt_listener_reconnects_after_broker_disconnect() {
+    let publish = mqtt::packet::v5_0::Publish::builder()
+        .topic_name("alerts/reconnected")
+        .expect("publish topic should be valid")
+        .payload("alive")
+        .build()
+        .expect("publish packet should build");
+    let (broker, shutdown_tx, broker_handle) = spawn_reconnecting_test_broker_v5(publish);
+    let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    block_on(driver.start_listening(RecordingSink {
+        events: Arc::clone(&events),
+    }))
+    .expect("listener should start");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if !events.lock().expect("events lock").is_empty() {
+            break;
+        }
+        assert!(std::time::Instant::now() < deadline, "expected event after reconnect");
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    assert_eq!(
+        events.lock().expect("events lock")[0].address,
+        Address::Channel("alerts/reconnected".to_string())
+    );
+    assert_eq!(
+        driver.listener_status().expect("listener status"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop after reconnect test");
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn mqtt_listener_keeps_running_with_ping_response() {
+    let (broker, shutdown_tx, broker_handle) = spawn_keepalive_test_broker_v5();
+    let driver = MqttDriver::new(Device {
+        id: "mqtt-device-keepalive".to_string(),
+        name: "MQTT Keepalive Device".to_string(),
+        status: DeviceStatus::Online,
+        endpoint: DeviceEndpoint::mqtt(MqttEndpointConfig {
+            broker,
+            client_id: "client-keepalive".to_string(),
+            auth: None,
+            tls: None,
+            keepalive_secs: Some(1),
+            clean_start: true,
+            session_expiry_secs: None,
+            topic_prefix: None,
+            supported_versions: vec![MqttProtocolVersion::V5_0],
+        }),
+        metadata: None,
+        max_connections: Some(4),
+        resources: Map::default(),
+        message_endpoints: Vec::new(),
+    });
+
+    block_on(driver.start_listening(NoopSink)).expect("listener should start");
+    thread::sleep(Duration::from_millis(1500));
+    assert_eq!(
+        driver.listener_status().expect("listener status"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop after keepalive test");
     let _ = shutdown_tx.send(());
     broker_handle.join().expect("broker thread should join");
 }

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -21,7 +21,7 @@ use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, Ht
 
 use crate::{
     runtime_stack::StackRuntime,
-    runtime::{build_connect_packet, routed_message_from_packet},
+    runtime::{build_connect_packet, normalize_broker_addr, routed_message_from_packet},
     types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
     MqttDriver, MqttListenerStatus,
 };
@@ -516,6 +516,13 @@ fn mqtt_subscribe_builds_version_specific_packet() {
         }
         other => panic!("expected v5 subscribe packet, got {other:?}"),
     }
+}
+
+#[test]
+fn normalize_broker_addr_adds_default_port_for_bracketed_ipv6() {
+    assert_eq!(normalize_broker_addr("mqtt://[::1]"), "[::1]:1883");
+    assert_eq!(normalize_broker_addr("[::1]"), "[::1]:1883");
+    assert_eq!(normalize_broker_addr("mqtt://[::1]:1884"), "[::1]:1884");
 }
 
 #[test]

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -3,8 +3,7 @@ use std::{
     future::Future,
     io::{Read, Write},
     net::TcpListener,
-    sync::{Arc, Mutex, mpsc},
-    task::{Context, Poll, Waker},
+    sync::{Arc, Mutex, OnceLock, mpsc},
     thread,
     time::Duration,
 };
@@ -14,11 +13,13 @@ use ferredge_core::prelude::{
     BrokerSubscriptionOptions, Command, Correlation, Device, DeviceEndpoint, DeviceStatus,
     EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle, Map, MqttEndpointConfig,
     MqttProtocolVersion, ProtocolBridge, RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
+    PubSub,
 };
 use mqtt_protocol_core::mqtt;
 use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
 
 use crate::{
+    runtime_stack::StackRuntime,
     runtime::{build_connect_packet, routed_message_from_packet},
     types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
     MqttDriver, MqttListenerStatus,
@@ -52,15 +53,8 @@ fn make_default_driver() -> MqttDriver {
 }
 
 fn block_on<F: Future>(future: F) -> F::Output {
-    let waker = Waker::noop();
-    let mut context = Context::from_waker(waker);
-    let mut future = std::pin::pin!(future);
-    loop {
-        match future.as_mut().poll(&mut context) {
-            Poll::Ready(output) => return output,
-            Poll::Pending => thread::yield_now(),
-        }
-    }
+    static RUNTIME: OnceLock<StackRuntime> = OnceLock::new();
+    RUNTIME.get_or_init(StackRuntime::default).block_on(future)
 }
 
 fn wait_for_status(
@@ -1054,6 +1048,62 @@ fn mqtt_listener_keeps_running_with_ping_response() {
     );
 
     block_on(driver.stop()).expect("driver should stop after keepalive test");
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn mqtt_same_driver_can_listen_and_control_subscriptions() {
+    let (broker, shutdown_tx, broker_handle) = spawn_keepalive_test_broker_v5();
+    let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
+
+    let subscribe_packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: "same-driver-sub".to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Subscribe {
+                channel: BrokerAddress {
+                    name: "ferredge/control".to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+                options: BrokerSubscriptionOptions::default(),
+            },
+            correlation: None,
+        },
+    })
+    .expect("subscribe packet should build");
+
+    let unsubscribe_packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: "same-driver-unsub".to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Unsubscribe {
+                channel: BrokerAddress {
+                    name: "ferredge/control".to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+            },
+            correlation: None,
+        },
+    })
+    .expect("unsubscribe packet should build");
+
+    block_on(driver.start_listening(NoopSink)).expect("listener should start");
+    block_on(driver.subscribe(subscribe_packet, NoopSink))
+        .expect("same driver should subscribe while listening");
+    block_on(driver.unsubscribe(unsubscribe_packet))
+        .expect("same driver should unsubscribe while listening");
+
+    assert_eq!(
+        driver.listener_status().expect("listener status"),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop after same-driver control test");
     let _ = shutdown_tx.send(());
     broker_handle.join().expect("broker thread should join");
 }

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -25,6 +25,12 @@ use crate::{
     MqttDriver, MqttListenerStatus,
 };
 
+const TEST_STATUS_TIMEOUT_SECS: u64 = 5;
+const TEST_BROKER_READ_TIMEOUT_MS: u64 = 100;
+const TEST_BROKER_PUBLISH_DELAY_MS: u64 = 150;
+const TEST_EVENT_WAIT_POLL_MS: u64 = 25;
+const TEST_KEEPALIVE_ASSERT_DELAY_MS: u64 = 1_500;
+
 fn make_driver(broker: String, supported_versions: Vec<MqttProtocolVersion>) -> MqttDriver {
     MqttDriver::new(Device {
         id: "mqtt-device-1".to_string(),
@@ -62,7 +68,7 @@ fn wait_for_status(
     rx: &mpsc::Receiver<MqttListenerStatus>,
     matcher: impl Fn(&MqttListenerStatus) -> bool,
 ) -> MqttListenerStatus {
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + Duration::from_secs(TEST_STATUS_TIMEOUT_SECS);
     loop {
         let timeout = deadline.saturating_duration_since(std::time::Instant::now());
         let status = rx
@@ -78,7 +84,10 @@ fn spawn_test_broker_v5(
     publish_after_connack: Option<mqtt::packet::v5_0::Publish>,
 ) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let publishes = publish_after_connack.into_iter().collect::<Vec<_>>();
-    spawn_test_broker_v5_with_publishes(publishes, Duration::from_millis(150))
+    spawn_test_broker_v5_with_publishes(
+        publishes,
+        Duration::from_millis(TEST_BROKER_PUBLISH_DELAY_MS),
+    )
 }
 
 fn spawn_test_broker_v5_with_publishes(
@@ -92,7 +101,7 @@ fn spawn_test_broker_v5_with_publishes(
     let handle = thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("broker should accept client");
         stream
-            .set_read_timeout(Some(Duration::from_millis(100)))
+            .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
             .expect("broker should set read timeout");
 
         let mut connect_buffer = [0u8; 4096];
@@ -148,7 +157,7 @@ fn spawn_reconnecting_test_broker_v5(
         for connection_idx in 0..2 {
             let (mut stream, _) = listener.accept().expect("broker should accept client");
             stream
-                .set_read_timeout(Some(Duration::from_millis(100)))
+                .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
                 .expect("broker should set read timeout");
 
             let mut connect_buffer = [0u8; 4096];
@@ -168,7 +177,7 @@ fn spawn_reconnecting_test_broker_v5(
                 continue;
             }
 
-            thread::sleep(Duration::from_millis(150));
+            thread::sleep(Duration::from_millis(TEST_BROKER_PUBLISH_DELAY_MS));
             stream
                 .write_all(&publish_after_reconnect.to_continuous_buffer())
                 .expect("broker should send publish after reconnect");
@@ -203,7 +212,7 @@ fn spawn_keepalive_test_broker_v5() -> (String, mpsc::Sender<()>, thread::JoinHa
     let handle = thread::spawn(move || {
         let (mut stream, _) = listener.accept().expect("broker should accept client");
         stream
-            .set_read_timeout(Some(Duration::from_millis(100)))
+            .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
             .expect("broker should set read timeout");
 
         let mut connect_buffer = [0u8; 4096];
@@ -995,13 +1004,13 @@ fn mqtt_listener_reconnects_after_broker_disconnect() {
     }))
     .expect("listener should start");
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + Duration::from_secs(TEST_STATUS_TIMEOUT_SECS);
     loop {
         if !events.lock().expect("events lock").is_empty() {
             break;
         }
         assert!(std::time::Instant::now() < deadline, "expected event after reconnect");
-        thread::sleep(Duration::from_millis(25));
+        thread::sleep(Duration::from_millis(TEST_EVENT_WAIT_POLL_MS));
     }
 
     assert_eq!(
@@ -1044,7 +1053,7 @@ fn mqtt_listener_keeps_running_with_ping_response() {
     });
 
     block_on(driver.start_listening(NoopSink)).expect("listener should start");
-    thread::sleep(Duration::from_millis(1500));
+    thread::sleep(Duration::from_millis(TEST_KEEPALIVE_ASSERT_DELAY_MS));
     assert_eq!(
         driver.listener_status().expect("listener status"),
         MqttListenerStatus::Running
@@ -1095,9 +1104,30 @@ fn mqtt_same_driver_can_listen_and_control_subscriptions() {
     })
     .expect("unsubscribe packet should build");
 
+    let publish_packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &Command {
+            id: "same-driver-pub".to_string(),
+            source_device_id: None,
+            target_device_id: driver.dvc.id.clone(),
+            intent: Intent::Send {
+                channel: BrokerAddress {
+                    name: "ferredge/control".to_string(),
+                    kind: Some(BrokerChannelKind::Topic),
+                },
+                payload: b"same-driver".to_vec(),
+                options: BrokerMessageOptions::default(),
+            },
+            correlation: None,
+        },
+    })
+    .expect("publish packet should build");
+
     block_on(driver.start_listening(NoopSink)).expect("listener should start");
     block_on(driver.subscribe(subscribe_packet, NoopSink))
         .expect("same driver should subscribe while listening");
+    block_on(driver.publish(publish_packet))
+        .expect("same driver should publish while listening");
     block_on(driver.unsubscribe(unsubscribe_packet))
         .expect("same driver should unsubscribe while listening");
 

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -10,10 +10,10 @@ use std::{
 
 use ferredge_core::prelude::{
     ActionEmitter, Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
-    BrokerSubscriptionOptions, Command, Correlation, Device, DeviceEndpoint, DeviceStatus,
-    EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle, Map, MqttEndpointConfig,
-    MqttProtocolVersion, ProtocolBridge, RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
-    PubSub,
+    BrokerReconnectConfig, BrokerSubscriptionOptions, Command, Correlation, Device,
+    DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle,
+    Map, MqttEndpointConfig, MqttProtocolVersion, ProtocolBridge, PubSub, RoutedEvent,
+    RoutedMessage, RoutedResult, TransportMeta,
 };
 use mqtt_protocol_core::mqtt;
 use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
@@ -39,6 +39,7 @@ fn make_driver(broker: String, supported_versions: Vec<MqttProtocolVersion>) -> 
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: Some("ferredge".to_string()),
+            reconnect: BrokerReconnectConfig::default(),
             supported_versions,
         }),
         metadata: None,
@@ -962,6 +963,7 @@ fn mqtt_connect_packet_maps_v5_session_expiry() {
         clean_start: true,
         session_expiry_secs: Some(3600),
         topic_prefix: None,
+        reconnect: BrokerReconnectConfig::default(),
         supported_versions: vec![MqttProtocolVersion::V5_0],
     })
     .expect("connect packet should build");
@@ -1032,6 +1034,7 @@ fn mqtt_listener_keeps_running_with_ping_response() {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),
         metadata: None,

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -371,6 +371,49 @@ fn mqtt_v5_publish_maps_reply_and_correlation_properties() {
 }
 
 #[test]
+fn mqtt_v5_publish_uses_command_id_as_correlation_when_reply_topic_present() {
+    let driver = make_default_driver();
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-implicit-corr".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Send {
+            channel: BrokerAddress {
+                name: "rpc/request".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            payload: b"{}".to_vec(),
+            options: BrokerMessageOptions {
+                delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
+                headers: Vec::new(),
+                reply_to: Some("rpc/reply".to_string()),
+                correlation_id: None,
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("v5 publish should build");
+
+    match packet.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            let mut saw_corr = false;
+            for prop in packet.props() {
+                if let mqtt::packet::Property::CorrelationData(prop) = prop {
+                    saw_corr = prop.val() == b"cmd-implicit-corr";
+                }
+            }
+            assert!(saw_corr);
+        }
+        other => panic!("expected v5 publish packet, got {other:?}"),
+    }
+}
+
+#[test]
 fn inbound_publish_packet_converts_to_routed_event() {
     let publish = mqtt::packet::v5_0::Publish::builder()
         .topic_name("sensors/temp")
@@ -399,6 +442,7 @@ fn inbound_publish_packet_converts_to_routed_event() {
         .unwrap();
 
     let message = routed_message_from_packet(
+        &mut HashMap::new(),
         &mut HashMap::new(),
         "mqtt-device-1",
         mqtt::packet::Packet::V5_0Publish(publish),
@@ -431,6 +475,53 @@ fn inbound_publish_packet_converts_to_routed_event() {
             }
         }
         other => panic!("expected routed event, got {other:?}"),
+    }
+}
+
+#[test]
+fn inbound_reply_publish_converts_to_routed_result_when_correlation_matches() {
+    let publish = mqtt::packet::v5_0::Publish::builder()
+        .topic_name("rpc/reply")
+        .unwrap()
+        .payload("done")
+        .props({
+            let mut props = mqtt::packet::Properties::new();
+            props.push(mqtt::packet::Property::CorrelationData(
+                mqtt::packet::CorrelationData::new(b"corr-77".to_vec()).unwrap(),
+            ));
+            props
+        })
+        .build()
+        .unwrap();
+
+    let message = routed_message_from_packet(
+        &mut HashMap::new(),
+        &mut HashMap::from([(
+            "corr-77".to_string(),
+            crate::runtime::PendingReplyRoute {
+                command_id: "cmd-77".to_string(),
+                reply_to: Some(Address::Channel("rpc/reply".to_string())),
+            },
+        )]),
+        "mqtt-device-1",
+        mqtt::packet::Packet::V5_0Publish(publish),
+    )
+    .expect("reply publish should convert");
+
+    match message {
+        RoutedMessage::Result(result) => {
+            assert_eq!(result.result.command_id, "cmd-77");
+            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Completed);
+            assert_eq!(result.result.payload, Some(b"done".to_vec()));
+            assert_eq!(
+                result.result.correlation,
+                Some(Correlation {
+                    request_id: "cmd-77".to_string(),
+                    reply_to: Some(Address::Channel("rpc/reply".to_string())),
+                })
+            );
+        }
+        other => panic!("expected routed result, got {other:?}"),
     }
 }
 

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -766,6 +766,108 @@ fn inbound_reply_publish_converts_to_routed_result_when_correlation_matches() {
 }
 
 #[test]
+fn v5_puback_failure_converts_to_rejected_result_with_reason_codes() {
+    let puback = mqtt::packet::v5_0::Puback::builder()
+        .packet_id(42u16)
+        .reason_code(mqtt::result_code::PubackReasonCode::QuotaExceeded)
+        .build()
+        .unwrap();
+
+    let message = routed_message_from_packet(
+        &mut HashMap::from([(42u16, "cmd-42".to_string())]),
+        &mut HashMap::new(),
+        "mqtt-device-1",
+        mqtt::packet::Packet::V5_0Puback(puback),
+    )
+    .expect("puback packet should convert");
+
+    match message {
+        RoutedMessage::Result(result) => {
+            assert_eq!(result.result.command_id, "cmd-42");
+            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(result.result.error, Some("QuotaExceeded".to_string()));
+            match result.transport {
+                Some(TransportMeta::Mqtt(meta)) => {
+                    assert_eq!(meta.packet_id, Some(42));
+                    assert_eq!(meta.reason_codes, vec!["QuotaExceeded".to_string()]);
+                }
+                other => panic!("expected MQTT transport metadata, got {other:?}"),
+            }
+        }
+        other => panic!("expected routed result, got {other:?}"),
+    }
+}
+
+#[test]
+fn v5_suback_partial_failure_converts_to_rejected_result_with_reason_codes() {
+    let suback = mqtt::packet::v5_0::Suback::builder()
+        .packet_id(7u16)
+        .reason_codes(vec![
+            mqtt::result_code::SubackReasonCode::GrantedQos1,
+            mqtt::result_code::SubackReasonCode::NotAuthorized,
+        ])
+        .build()
+        .unwrap();
+
+    let message = routed_message_from_packet(
+        &mut HashMap::from([(7u16, "cmd-sub-7".to_string())]),
+        &mut HashMap::new(),
+        "mqtt-device-1",
+        mqtt::packet::Packet::V5_0Suback(suback),
+    )
+    .expect("suback packet should convert");
+
+    match message {
+        RoutedMessage::Result(result) => {
+            assert_eq!(result.result.command_id, "cmd-sub-7");
+            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(result.result.error, Some("NotAuthorized".to_string()));
+            match result.transport {
+                Some(TransportMeta::Mqtt(meta)) => {
+                    assert_eq!(
+                        meta.reason_codes,
+                        vec!["GrantedQos1".to_string(), "NotAuthorized".to_string()]
+                    );
+                }
+                other => panic!("expected MQTT transport metadata, got {other:?}"),
+            }
+        }
+        other => panic!("expected routed result, got {other:?}"),
+    }
+}
+
+#[test]
+fn v5_disconnect_failure_converts_to_rejected_transport_result() {
+    let disconnect = mqtt::packet::v5_0::Disconnect::builder()
+        .reason_code(mqtt::result_code::DisconnectReasonCode::ServerBusy)
+        .build()
+        .unwrap();
+
+    let message = routed_message_from_packet(
+        &mut HashMap::new(),
+        &mut HashMap::new(),
+        "mqtt-device-1",
+        mqtt::packet::Packet::V5_0Disconnect(disconnect),
+    )
+    .expect("disconnect packet should convert");
+
+    match message {
+        RoutedMessage::Result(result) => {
+            assert_eq!(result.result.command_id, "__mqtt_disconnect__");
+            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(result.result.error, Some("ServerBusy".to_string()));
+            match result.transport {
+                Some(TransportMeta::Mqtt(meta)) => {
+                    assert_eq!(meta.reason_codes, vec!["ServerBusy".to_string()]);
+                }
+                other => panic!("expected MQTT transport metadata, got {other:?}"),
+            }
+        }
+        other => panic!("expected routed result, got {other:?}"),
+    }
+}
+
+#[test]
 fn mqtt_listener_status_starts_stopped() {
     let driver = make_default_driver();
 

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -65,7 +65,7 @@ fn wait_for_status(
     rx: &mpsc::Receiver<MqttListenerStatus>,
     matcher: impl Fn(&MqttListenerStatus) -> bool,
 ) -> MqttListenerStatus {
-    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
     loop {
         let timeout = deadline.saturating_duration_since(std::time::Instant::now());
         let status = rx
@@ -79,6 +79,14 @@ fn wait_for_status(
 
 fn spawn_test_broker_v5(
     publish_after_connack: Option<mqtt::packet::v5_0::Publish>,
+) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let publishes = publish_after_connack.into_iter().collect::<Vec<_>>();
+    spawn_test_broker_v5_with_publishes(publishes, Duration::from_millis(150))
+}
+
+fn spawn_test_broker_v5_with_publishes(
+    publishes_after_connack: Vec<mqtt::packet::v5_0::Publish>,
+    publish_delay: Duration,
 ) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
     let addr = listener.local_addr().expect("test broker should have local addr");
@@ -103,8 +111,8 @@ fn spawn_test_broker_v5(
             .write_all(&connack.to_continuous_buffer())
             .expect("broker should send connack");
 
-        if let Some(publish) = publish_after_connack {
-            thread::sleep(Duration::from_millis(150));
+        for publish in publishes_after_connack {
+            thread::sleep(publish_delay);
             stream
                 .write_all(&publish.to_continuous_buffer())
                 .expect("broker should send publish");

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -10,10 +10,11 @@ use std::{
 
 use ferredge_core::prelude::{
     ActionEmitter, Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
-    BrokerReconnectConfig, BrokerSubscriptionOptions, Command, Correlation, Device,
-    DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle,
-    Map, MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion, ProtocolBridge, PubSub,
-    RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
+    BrokerReconnectConfig, BrokerSubscriptionOptions, ChannelReceiver, Command, Correlation,
+    Device, DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent,
+    Lifecycle, Map, MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion,
+    ProtocolBridge, PubSub, RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
+    AsyncRuntime,
 };
 use mqtt_protocol_core::mqtt;
 use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
@@ -24,6 +25,8 @@ use crate::{
     types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
     MqttDriver, MqttListenerStatus,
 };
+
+type RuntimeReceiver<T> = <StackRuntime as AsyncRuntime>::Receiver<T>;
 
 const TEST_STATUS_TIMEOUT_SECS: u64 = 5;
 const TEST_BROKER_READ_TIMEOUT_MS: u64 = 100;
@@ -66,15 +69,16 @@ fn block_on<F: Future>(future: F) -> F::Output {
 }
 
 fn wait_for_status(
-    rx: &mpsc::Receiver<MqttListenerStatus>,
+    rx: &mut RuntimeReceiver<MqttListenerStatus>,
     matcher: impl Fn(&MqttListenerStatus) -> bool,
 ) -> MqttListenerStatus {
     let deadline = std::time::Instant::now() + Duration::from_secs(TEST_STATUS_TIMEOUT_SECS);
     loop {
-        let timeout = deadline.saturating_duration_since(std::time::Instant::now());
-        let status = rx
-            .recv_timeout(timeout)
-            .expect("listener status should arrive before timeout");
+        assert!(
+            std::time::Instant::now() < deadline,
+            "listener status should arrive before timeout"
+        );
+        let status = block_on(rx.recv()).expect("listener status should arrive before timeout");
         if matcher(&status) {
             return status;
         }
@@ -901,12 +905,12 @@ fn mqtt_listener_error_can_be_cleared_without_runtime() {
 fn mqtt_listener_status_subscription_receives_initial_state() {
     let driver = make_default_driver();
 
-    let rx = driver
+    let mut rx = driver
         .subscribe_listener_status()
         .expect("listener status subscription should succeed");
 
     assert_eq!(
-        rx.recv().expect("initial listener status should be sent"),
+        block_on(rx.recv()).expect("initial listener status should be sent"),
         MqttListenerStatus::Stopped
     );
 }
@@ -914,17 +918,17 @@ fn mqtt_listener_status_subscription_receives_initial_state() {
 #[test]
 fn mqtt_listener_status_subscription_receives_clear_transition() {
     let driver = make_default_driver();
-    let rx = driver
+    let mut rx = driver
         .subscribe_listener_status()
         .expect("listener status subscription should succeed");
-    let _ = rx.recv().expect("initial listener status should be sent");
+    let _ = block_on(rx.recv()).expect("initial listener status should be sent");
 
     driver
         .clear_listener_error()
         .expect("clearing empty listener error should succeed");
 
     assert_eq!(
-        rx.recv().expect("listener status transition should be sent"),
+        block_on(rx.recv()).expect("listener status transition should be sent"),
         MqttListenerStatus::Stopped
     );
 }
@@ -933,32 +937,32 @@ fn mqtt_listener_status_subscription_receives_clear_transition() {
 fn mqtt_listener_can_start_stop_and_restart() {
     let (broker, shutdown_tx, broker_handle) = spawn_test_broker_v5(None);
     let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
-    let rx = driver
+    let mut rx = driver
         .subscribe_listener_status()
         .expect("listener status subscription should succeed");
-    let _ = rx.recv().expect("initial listener status should be sent");
+    let _ = block_on(rx.recv()).expect("initial listener status should be sent");
 
     block_on(driver.start_listening(NoopSink)).expect("listener should start");
     assert_eq!(
-        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Running)),
+        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Running)),
         MqttListenerStatus::Running
     );
 
     block_on(driver.stop_listening()).expect("listener should stop");
     assert_eq!(
-        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Stopped)),
         MqttListenerStatus::Stopped
     );
 
     block_on(driver.start_listening(NoopSink)).expect("listener should restart");
     assert_eq!(
-        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Running)),
+        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Running)),
         MqttListenerStatus::Running
     );
 
     block_on(driver.stop()).expect("driver should stop cleanly");
     assert!(matches!(
-        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Stopped)),
         MqttListenerStatus::Stopped
     ));
 
@@ -976,13 +980,14 @@ fn mqtt_listener_reports_failed_when_sink_rejects_event() {
         .expect("publish packet should build");
     let (broker, shutdown_tx, broker_handle) = spawn_test_broker_v5(Some(publish));
     let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
-    let rx = driver
+    let mut rx = driver
         .subscribe_listener_status()
         .expect("listener status subscription should succeed");
-    let _ = rx.recv().expect("initial listener status should be sent");
+    let _ = block_on(rx.recv()).expect("initial listener status should be sent");
 
     block_on(driver.start_listening(FailOnEventSink)).expect("listener should start");
-    let failed = wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Failed(_)));
+    let failed =
+        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Failed(_)));
     assert_eq!(
         failed,
         MqttListenerStatus::Failed("failed to forward MQTT event to sink".to_string())

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -12,8 +12,8 @@ use ferredge_core::prelude::{
     ActionEmitter, Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
     BrokerReconnectConfig, BrokerSubscriptionOptions, Command, Correlation, Device,
     DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent, Lifecycle,
-    Map, MqttEndpointConfig, MqttProtocolVersion, ProtocolBridge, PubSub, RoutedEvent,
-    RoutedMessage, RoutedResult, TransportMeta,
+    Map, MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion, ProtocolBridge, PubSub,
+    RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
 };
 use mqtt_protocol_core::mqtt;
 use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
@@ -45,6 +45,7 @@ fn make_driver(broker: String, supported_versions: Vec<MqttProtocolVersion>) -> 
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: Some("ferredge".to_string()),
+            connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions,
         }),
@@ -1074,6 +1075,7 @@ fn mqtt_connect_packet_maps_v5_session_expiry() {
         clean_start: true,
         session_expiry_secs: Some(3600),
         topic_prefix: None,
+        connect_properties: MqttConnectProperties::default(),
         reconnect: BrokerReconnectConfig::default(),
         supported_versions: vec![MqttProtocolVersion::V5_0],
     })
@@ -1145,6 +1147,7 @@ fn mqtt_listener_keeps_running_with_ping_response() {
             clean_start: true,
             session_expiry_secs: None,
             topic_prefix: None,
+            connect_properties: MqttConnectProperties::default(),
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -12,7 +12,7 @@ use std::{
 use ferredge_core::prelude::{
     Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions, EventSink,
     EventSource, Correlation, Device, DeviceEndpoint, DeviceStatus, Lifecycle, Map,
-    MqttEndpointConfig, MqttProtocolVersion, RoutedEvent, RoutedMessage,
+    MqttEndpointConfig, MqttProtocolVersion, RoutedEvent, RoutedMessage, TransportMeta,
 };
 use mqtt_protocol_core::mqtt;
 
@@ -232,8 +232,8 @@ fn mqtt_subscribe_builds_version_specific_packet() {
             },
             options: BrokerSubscriptionOptions {
                 delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
-                durable_name: None,
-                shared_group: None,
+                durable_name: Some("durable-a".to_string()),
+                shared_group: Some("shared-a".to_string()),
             },
         },
         correlation: None,
@@ -246,7 +246,72 @@ fn mqtt_subscribe_builds_version_specific_packet() {
     .expect("subscribe should build");
 
     assert_eq!(packet.command_id, "cmd-3");
-    assert!(matches!(packet.packet, MqttWirePacket::V5Subscribe(_)));
+    match packet.packet {
+        MqttWirePacket::V5Subscribe(packet) => {
+            let mut saw_subscription_identifier = false;
+            let mut saw_durable = false;
+            let mut saw_shared = false;
+            for prop in packet.props() {
+                match prop {
+                    mqtt::packet::Property::SubscriptionIdentifier(prop) => {
+                        saw_subscription_identifier = prop.val() == 1;
+                    }
+                    mqtt::packet::Property::UserProperty(prop) => {
+                        if prop.key() == "ferredge-durable-name" && prop.val() == "durable-a" {
+                            saw_durable = true;
+                        }
+                        if prop.key() == "ferredge-shared-group" && prop.val() == "shared-a" {
+                            saw_shared = true;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            assert!(saw_subscription_identifier);
+            assert!(saw_durable);
+            assert!(saw_shared);
+        }
+        other => panic!("expected v5 subscribe packet, got {other:?}"),
+    }
+}
+
+#[test]
+fn mqtt_unsubscribe_v5_includes_command_id_user_property() {
+    let driver = make_default_driver();
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-unsub-1".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Unsubscribe {
+            channel: BrokerAddress {
+                name: "alerts/#".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("unsubscribe should build");
+
+    match packet.packet {
+        MqttWirePacket::V5Unsubscribe(packet) => {
+            let mut saw_command_id = false;
+            for prop in packet.props() {
+                if let mqtt::packet::Property::UserProperty(prop) = prop
+                    && prop.key() == "ferredge-command-id"
+                    && prop.val() == "cmd-unsub-1"
+                {
+                    saw_command_id = true;
+                }
+            }
+            assert!(saw_command_id);
+        }
+        other => panic!("expected v5 unsubscribe packet, got {other:?}"),
+    }
 }
 
 #[test]
@@ -313,11 +378,20 @@ fn inbound_publish_packet_converts_to_routed_event() {
         .payload("42")
         .props({
             let mut props = mqtt::packet::Properties::new();
+            props.push(mqtt::packet::Property::ContentType(
+                mqtt::packet::ContentType::new("application/json").unwrap(),
+            ));
             props.push(mqtt::packet::Property::ResponseTopic(
                 mqtt::packet::ResponseTopic::new("rpc/reply").unwrap(),
             ));
             props.push(mqtt::packet::Property::CorrelationData(
                 mqtt::packet::CorrelationData::new(b"corr-42".to_vec()).unwrap(),
+            ));
+            props.push(mqtt::packet::Property::SubscriptionIdentifier(
+                mqtt::packet::SubscriptionIdentifier::new(7).unwrap(),
+            ));
+            props.push(mqtt::packet::Property::UserProperty(
+                mqtt::packet::UserProperty::new("source", "broker-a").unwrap(),
             ));
             props
         })
@@ -342,6 +416,19 @@ fn inbound_publish_packet_converts_to_routed_event() {
                     reply_to: Some(Address::Channel("rpc/reply".to_string())),
                 })
             );
+            match event.transport {
+                Some(TransportMeta::Mqtt(meta)) => {
+                    assert_eq!(meta.content_type, Some("application/json".to_string()));
+                    assert_eq!(meta.response_topic, Some("rpc/reply".to_string()));
+                    assert_eq!(meta.correlation_data, Some("corr-42".to_string()));
+                    assert_eq!(meta.subscription_identifiers, vec![7]);
+                    assert_eq!(
+                        meta.user_properties,
+                        vec![("source".to_string(), "broker-a".to_string())]
+                    );
+                }
+                other => panic!("expected MQTT transport metadata, got {other:?}"),
+            }
         }
         other => panic!("expected routed event, got {other:?}"),
     }

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -1,0 +1,256 @@
+use std::collections::HashMap;
+
+use ferredge_core::prelude::{
+    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions,
+    Correlation, Device, DeviceEndpoint, DeviceStatus, Map, MqttEndpointConfig,
+    MqttProtocolVersion, RoutedMessage,
+};
+use mqtt_protocol_core::mqtt;
+
+use crate::{
+    runtime::routed_message_from_packet,
+    types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
+    MqttDriver, MqttListenerStatus,
+};
+
+fn make_driver(supported_versions: Vec<MqttProtocolVersion>) -> MqttDriver {
+    MqttDriver::new(Device {
+        id: "mqtt-device-1".to_string(),
+        name: "MQTT Device".to_string(),
+        status: DeviceStatus::Online,
+        endpoint: DeviceEndpoint::mqtt(MqttEndpointConfig {
+            broker: "mqtt://broker".to_string(),
+            client_id: "client-1".to_string(),
+            auth: None,
+            tls: None,
+            keepalive_secs: Some(30),
+            clean_start: true,
+            session_expiry_secs: None,
+            topic_prefix: Some("ferredge".to_string()),
+            supported_versions,
+        }),
+        metadata: None,
+        max_connections: Some(16),
+        resources: Map::default(),
+        message_endpoints: Vec::new(),
+    })
+}
+
+#[test]
+fn mqtt_send_prefers_v5_packet_when_available() {
+    let driver = make_driver(vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0]);
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-1".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Send {
+            channel: BrokerAddress {
+                name: "sensors/temp".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            payload: b"42".to_vec(),
+            options: BrokerMessageOptions {
+                delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
+                headers: Vec::new(),
+                reply_to: None,
+                correlation_id: None,
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("v5 publish should build");
+
+    assert_eq!(packet.command_id, "cmd-1");
+    assert!(matches!(packet.packet, MqttWirePacket::V5Publish(_)));
+}
+
+#[test]
+fn mqtt_send_falls_back_to_v3_when_v5_not_available() {
+    let driver = make_driver(vec![MqttProtocolVersion::V3_1_1]);
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-2".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Send {
+            channel: BrokerAddress {
+                name: "sensors/temp".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            payload: b"42".to_vec(),
+            options: BrokerMessageOptions::default(),
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("v3 publish should build");
+
+    assert_eq!(packet.command_id, "cmd-2");
+    assert!(matches!(packet.packet, MqttWirePacket::V3Publish(_)));
+}
+
+#[test]
+fn mqtt_subscribe_builds_version_specific_packet() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-3".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Subscribe {
+            channel: BrokerAddress {
+                name: "alerts/#".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            options: BrokerSubscriptionOptions {
+                delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
+                durable_name: None,
+                shared_group: None,
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("subscribe should build");
+
+    assert_eq!(packet.command_id, "cmd-3");
+    assert!(matches!(packet.packet, MqttWirePacket::V5Subscribe(_)));
+}
+
+#[test]
+fn mqtt_v5_publish_maps_reply_and_correlation_properties() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-4".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Send {
+            channel: BrokerAddress {
+                name: "rpc/request".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            payload: b"{}".to_vec(),
+            options: BrokerMessageOptions {
+                delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
+                headers: vec![("content-type".to_string(), "application/json".to_string())],
+                reply_to: Some("rpc/reply".to_string()),
+                correlation_id: Some("corr-123".to_string()),
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("v5 publish should build");
+
+    match packet.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            let mut saw_reply = false;
+            let mut saw_corr = false;
+            let mut saw_content_type = false;
+            for prop in packet.props() {
+                match prop {
+                    mqtt::packet::Property::ResponseTopic(prop) => {
+                        saw_reply = prop.val() == "rpc/reply";
+                    }
+                    mqtt::packet::Property::CorrelationData(prop) => {
+                        saw_corr = prop.val() == b"corr-123";
+                    }
+                    mqtt::packet::Property::ContentType(prop) => {
+                        saw_content_type = prop.val() == "application/json";
+                    }
+                    _ => {}
+                }
+            }
+            assert!(saw_reply);
+            assert!(saw_corr);
+            assert!(saw_content_type);
+        }
+        other => panic!("expected v5 publish packet, got {other:?}"),
+    }
+}
+
+#[test]
+fn inbound_publish_packet_converts_to_routed_event() {
+    let publish = mqtt::packet::v5_0::Publish::builder()
+        .topic_name("sensors/temp")
+        .unwrap()
+        .payload("42")
+        .props({
+            let mut props = mqtt::packet::Properties::new();
+            props.push(mqtt::packet::Property::ResponseTopic(
+                mqtt::packet::ResponseTopic::new("rpc/reply").unwrap(),
+            ));
+            props.push(mqtt::packet::Property::CorrelationData(
+                mqtt::packet::CorrelationData::new(b"corr-42".to_vec()).unwrap(),
+            ));
+            props
+        })
+        .build()
+        .unwrap();
+
+    let message = routed_message_from_packet(
+        &mut HashMap::new(),
+        "mqtt-device-1",
+        mqtt::packet::Packet::V5_0Publish(publish),
+    )
+    .expect("publish packet should convert");
+
+    match message {
+        RoutedMessage::Event(event) => {
+            assert_eq!(event.address, Address::Channel("sensors/temp".to_string()));
+            assert_eq!(event.payload, b"42".to_vec());
+            assert_eq!(
+                event.correlation,
+                Some(Correlation {
+                    request_id: "corr-42".to_string(),
+                    reply_to: Some(Address::Channel("rpc/reply".to_string())),
+                })
+            );
+        }
+        other => panic!("expected routed event, got {other:?}"),
+    }
+}
+
+#[test]
+fn mqtt_listener_status_starts_stopped() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+
+    assert_eq!(
+        driver.listener_status().expect("listener status should be readable"),
+        MqttListenerStatus::Stopped
+    );
+    assert_eq!(
+        driver
+            .last_listener_error()
+            .expect("listener error should be readable"),
+        None
+    );
+}
+
+#[test]
+fn mqtt_listener_error_can_be_cleared_without_runtime() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+
+    driver
+        .clear_listener_error()
+        .expect("clearing empty listener error should succeed");
+    assert_eq!(
+        driver.listener_status().expect("listener status should be readable"),
+        MqttListenerStatus::Stopped
+    );
+}

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -383,8 +383,7 @@ fn make_http_driver() -> HttpDriver {
         },
     );
 
-    HttpDriver {
-        dvc: Device {
+    HttpDriver::new(Device {
             id: "http-device-1".to_string(),
             name: "HTTP Device".to_string(),
             status: DeviceStatus::Online,
@@ -395,8 +394,7 @@ fn make_http_driver() -> HttpDriver {
             max_connections: Some(4),
             resources,
             message_endpoints: Vec::new(),
-        },
-    }
+        })
 }
 
 #[test]

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -9,25 +9,27 @@ use std::{
 };
 
 use ferredge_core::prelude::{
-    ActionEmitter, Address, AsyncRuntime, BrokerAddress, BrokerChannelKind,
-    BrokerMessageOptions, BrokerMessageProtocolOptions, BrokerReconnectConfig,
-    BrokerSubscriptionOptions, BrokerSubscriptionProtocolOptions, ChannelReceiver, Command,
-    Correlation, DeliveryGuarantee, Device, DeviceEndpoint, DeviceStatus, EventSink,
-    EventSource, HttpEndpointConfig, Intent, Lifecycle, Map, MqttConnectProperties,
-    MqttEndpointConfig, MqttMessageOptions, MqttPayloadFormat, MqttProtocolVersion,
-    MqttRetainHandling, MqttSubscriptionOptions, MqttWillConfig, ProtocolBridge, PubSub,
-    RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
+    ActionEmitter, Address, AsyncRuntime, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
+    BrokerMessageProtocolOptions, BrokerReconnectConfig, BrokerSubscriptionOptions,
+    BrokerSubscriptionProtocolOptions, ChannelReceiver, Command, Correlation, DeliveryGuarantee,
+    Device, DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent,
+    Lifecycle, Map, MqttConnectProperties, MqttEndpointConfig, MqttMessageOptions,
+    MqttPayloadFormat, MqttProtocolVersion, MqttRetainHandling, MqttSubscriptionOptions,
+    MqttWillConfig, ProtocolBridge, PubSub, RoutedEvent, RoutedMessage, RoutedResult,
+    TransportMeta,
+};
+use ferredge_proto_http::{
+    HttpCommandRef, HttpDriver, HttpRequest, attributes::HttpResourceAttributes,
 };
 use mqtt_protocol_core::mqtt;
 use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
-use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
 
 use crate::{
-    runtime_stack::StackRuntime,
-    runtime::{build_connect_packet, normalize_broker_addr, routed_message_from_packet},
-    types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
     MqttAuthChallenge, MqttAuthFlowReason, MqttAuthResponse, MqttAuthStage, MqttDriver,
     MqttListenerStatus,
+    runtime::{build_connect_packet, normalize_broker_addr, routed_message_from_packet},
+    runtime_stack::StackRuntime,
+    types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
 };
 
 type RuntimeReceiver<T> = <StackRuntime as AsyncRuntime>::Receiver<T>;
@@ -105,7 +107,9 @@ fn spawn_test_broker_v5_with_publishes(
     publish_delay: Duration,
 ) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
-    let addr = listener.local_addr().expect("test broker should have local addr");
+    let addr = listener
+        .local_addr()
+        .expect("test broker should have local addr");
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
     let handle = thread::spawn(move || {
@@ -160,7 +164,9 @@ fn spawn_reconnecting_test_broker_v5(
     publish_after_reconnect: mqtt::packet::v5_0::Publish,
 ) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
-    let addr = listener.local_addr().expect("test broker should have local addr");
+    let addr = listener
+        .local_addr()
+        .expect("test broker should have local addr");
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
     let handle = thread::spawn(move || {
@@ -216,7 +222,9 @@ fn spawn_reconnecting_test_broker_v5(
 
 fn spawn_keepalive_test_broker_v5() -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
-    let addr = listener.local_addr().expect("test broker should have local addr");
+    let addr = listener
+        .local_addr()
+        .expect("test broker should have local addr");
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
     let handle = thread::spawn(move || {
@@ -371,20 +379,22 @@ impl ProtocolBridge for TestBridge {
         E: ActionEmitter + Send,
     {
         if let Intent::Read { resource } = &command.intent {
-            emitter.emit(RoutedMessage::Command(Command {
-                id: format!("{}-mqtt", command.id),
-                source_device_id: Some(command.target_device_id.clone()),
-                target_device_id: "mqtt-device-1".to_string(),
-                intent: Intent::Send {
-                    channel: BrokerAddress {
-                        name: format!("requests/{resource}"),
-                        kind: Some(BrokerChannelKind::Topic),
+            emitter
+                .emit(RoutedMessage::Command(Command {
+                    id: format!("{}-mqtt", command.id),
+                    source_device_id: Some(command.target_device_id.clone()),
+                    target_device_id: "mqtt-device-1".to_string(),
+                    intent: Intent::Send {
+                        channel: BrokerAddress {
+                            name: format!("requests/{resource}"),
+                            kind: Some(BrokerChannelKind::Topic),
+                        },
+                        payload: Vec::new(),
+                        options: BrokerMessageOptions::default(),
                     },
-                    payload: Vec::new(),
-                    options: BrokerMessageOptions::default(),
-                },
-                correlation: command.correlation.clone(),
-            })).map_err(|_| ())?;
+                    correlation: command.correlation.clone(),
+                }))
+                .map_err(|_| ())?;
         }
         Ok(())
     }
@@ -396,25 +406,33 @@ impl ProtocolBridge for TestBridge {
         if let Address::Channel(channel) = &event.address
             && channel == "sensors/temp"
         {
-            emitter.emit(RoutedMessage::Command(Command {
-                id: "bridge-http-write".to_string(),
-                source_device_id: Some(event.source.device_id.clone()),
-                target_device_id: "http-device-1".to_string(),
-                intent: Intent::Write {
-                    resource: "setpoint".to_string(),
-                    payload: event.payload.clone(),
-                },
-                correlation: event.correlation.clone(),
-            })).map_err(|_| ())?;
+            emitter
+                .emit(RoutedMessage::Command(Command {
+                    id: "bridge-http-write".to_string(),
+                    source_device_id: Some(event.source.device_id.clone()),
+                    target_device_id: "http-device-1".to_string(),
+                    intent: Intent::Write {
+                        resource: "setpoint".to_string(),
+                        payload: event.payload.clone(),
+                    },
+                    correlation: event.correlation.clone(),
+                }))
+                .map_err(|_| ())?;
         }
         Ok(())
     }
 
-    async fn bridge_result<E>(&self, result: &RoutedResult, emitter: &mut E) -> Result<(), Self::Error>
+    async fn bridge_result<E>(
+        &self,
+        result: &RoutedResult,
+        emitter: &mut E,
+    ) -> Result<(), Self::Error>
     where
         E: ActionEmitter + Send,
     {
-        emitter.emit(RoutedMessage::Result(result.clone())).map_err(|_| ())
+        emitter
+            .emit(RoutedMessage::Result(result.clone()))
+            .map_err(|_| ())
     }
 }
 
@@ -435,17 +453,17 @@ fn make_http_driver() -> HttpDriver {
     );
 
     HttpDriver::new(Device {
-            id: "http-device-1".to_string(),
-            name: "HTTP Device".to_string(),
-            status: DeviceStatus::Online,
-            endpoint: DeviceEndpoint::http(HttpEndpointConfig {
-                url: "127.0.0.1:8080".to_string(),
-            }),
-            metadata: None,
-            max_connections: Some(4),
-            resources,
-            message_endpoints: Vec::new(),
-        })
+        id: "http-device-1".to_string(),
+        name: "HTTP Device".to_string(),
+        status: DeviceStatus::Online,
+        endpoint: DeviceEndpoint::http(HttpEndpointConfig {
+            url: "127.0.0.1:8080".to_string(),
+        }),
+        metadata: None,
+        max_connections: Some(4),
+        resources,
+        message_endpoints: Vec::new(),
+    })
 }
 
 #[test]
@@ -484,7 +502,10 @@ fn mqtt_send_prefers_v5_packet_when_available() {
 
 #[test]
 fn mqtt_send_falls_back_to_v3_when_v5_not_available() {
-    let driver = make_driver("mqtt://broker".to_string(), vec![MqttProtocolVersion::V3_1_1]);
+    let driver = make_driver(
+        "mqtt://broker".to_string(),
+        vec![MqttProtocolVersion::V3_1_1],
+    );
     let command = ferredge_core::prelude::Command {
         id: "cmd-2".to_string(),
         source_device_id: None,
@@ -551,7 +572,10 @@ fn mqtt_subscribe_builds_version_specific_packet() {
     match packet.packet {
         MqttWirePacket::V5Subscribe(packet) => {
             let mut saw_subscription_identifier = false;
-            assert_eq!(packet.entries()[0].topic_filter(), "$share/shared-a/alerts/#");
+            assert_eq!(
+                packet.entries()[0].topic_filter(),
+                "$share/shared-a/alerts/#"
+            );
             assert!(packet.entries()[0].sub_opts().nl());
             assert!(packet.entries()[0].sub_opts().rap());
             assert_eq!(
@@ -872,7 +896,10 @@ fn inbound_reply_publish_converts_to_routed_result_when_correlation_matches() {
     match message {
         RoutedMessage::Result(result) => {
             assert_eq!(result.result.command_id, "cmd-77");
-            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Completed);
+            assert_eq!(
+                result.result.state,
+                ferredge_core::prelude::DeliveryState::Completed
+            );
             assert_eq!(result.result.payload, Some(b"done".to_vec()));
             assert_eq!(
                 result.result.correlation,
@@ -905,7 +932,10 @@ fn v5_puback_failure_converts_to_rejected_result_with_reason_codes() {
     match message {
         RoutedMessage::Result(result) => {
             assert_eq!(result.result.command_id, "cmd-42");
-            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(
+                result.result.state,
+                ferredge_core::prelude::DeliveryState::Rejected
+            );
             assert_eq!(result.result.error, Some("QuotaExceeded".to_string()));
             match result.transport {
                 Some(TransportMeta::Mqtt(meta)) => {
@@ -941,7 +971,10 @@ fn v5_suback_partial_failure_converts_to_rejected_result_with_reason_codes() {
     match message {
         RoutedMessage::Result(result) => {
             assert_eq!(result.result.command_id, "cmd-sub-7");
-            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(
+                result.result.state,
+                ferredge_core::prelude::DeliveryState::Rejected
+            );
             assert_eq!(result.result.error, Some("NotAuthorized".to_string()));
             match result.transport {
                 Some(TransportMeta::Mqtt(meta)) => {
@@ -975,7 +1008,10 @@ fn v5_disconnect_failure_converts_to_rejected_transport_result() {
     match message {
         RoutedMessage::Result(result) => {
             assert_eq!(result.result.command_id, "__mqtt_disconnect__");
-            assert_eq!(result.result.state, ferredge_core::prelude::DeliveryState::Rejected);
+            assert_eq!(
+                result.result.state,
+                ferredge_core::prelude::DeliveryState::Rejected
+            );
             assert_eq!(result.result.error, Some("ServerBusy".to_string()));
             match result.transport {
                 Some(TransportMeta::Mqtt(meta)) => {
@@ -993,7 +1029,9 @@ fn mqtt_listener_status_starts_stopped() {
     let driver = make_default_driver();
 
     assert_eq!(
-        driver.listener_status().expect("listener status should be readable"),
+        driver
+            .listener_status()
+            .expect("listener status should be readable"),
         MqttListenerStatus::Stopped
     );
     assert_eq!(
@@ -1012,7 +1050,9 @@ fn mqtt_listener_error_can_be_cleared_without_runtime() {
         .clear_listener_error()
         .expect("clearing empty listener error should succeed");
     assert_eq!(
-        driver.listener_status().expect("listener status should be readable"),
+        driver
+            .listener_status()
+            .expect("listener status should be readable"),
         MqttListenerStatus::Stopped
     );
 }
@@ -1060,25 +1100,37 @@ fn mqtt_listener_can_start_stop_and_restart() {
 
     block_on(driver.start_listening(NoopSink)).expect("listener should start");
     assert_eq!(
-        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Running)),
+        wait_for_status(&mut rx, |status| matches!(
+            status,
+            MqttListenerStatus::Running
+        )),
         MqttListenerStatus::Running
     );
 
     block_on(driver.stop_listening()).expect("listener should stop");
     assert_eq!(
-        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        wait_for_status(&mut rx, |status| matches!(
+            status,
+            MqttListenerStatus::Stopped
+        )),
         MqttListenerStatus::Stopped
     );
 
     block_on(driver.start_listening(NoopSink)).expect("listener should restart");
     assert_eq!(
-        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Running)),
+        wait_for_status(&mut rx, |status| matches!(
+            status,
+            MqttListenerStatus::Running
+        )),
         MqttListenerStatus::Running
     );
 
     block_on(driver.stop()).expect("driver should stop cleanly");
     assert!(matches!(
-        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        wait_for_status(&mut rx, |status| matches!(
+            status,
+            MqttListenerStatus::Stopped
+        )),
         MqttListenerStatus::Stopped
     ));
 
@@ -1102,8 +1154,9 @@ fn mqtt_listener_reports_failed_when_sink_rejects_event() {
     let _ = block_on(rx.recv()).expect("initial listener status should be sent");
 
     block_on(driver.start_listening(FailOnEventSink)).expect("listener should start");
-    let failed =
-        wait_for_status(&mut rx, |status| matches!(status, MqttListenerStatus::Failed(_)));
+    let failed = wait_for_status(&mut rx, |status| {
+        matches!(status, MqttListenerStatus::Failed(_))
+    });
     assert_eq!(
         failed,
         MqttListenerStatus::Failed("failed to forward MQTT event to sink".to_string())
@@ -1138,7 +1191,8 @@ fn bridge_can_translate_mqtt_event_into_http_request() {
     };
 
     block_on(bridge.bridge_event(&event, &mut emitter)).expect("bridge should succeed");
-    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command") else {
+    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command")
+    else {
         panic!("expected bridged command");
     };
     let request = HttpRequest::try_from(HttpCommandRef {
@@ -1168,7 +1222,8 @@ fn bridge_can_translate_http_command_into_mqtt_publish() {
     };
 
     block_on(bridge.bridge_command(&command, &mut emitter)).expect("bridge should succeed");
-    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command") else {
+    let RoutedMessage::Command(command) = emitter.0.pop().expect("bridge should emit command")
+    else {
         panic!("expected bridged command");
     };
     let packet = MqttPacketRequest::try_from(MqttCommandRef {
@@ -1206,10 +1261,12 @@ fn mqtt_connect_packet_maps_v5_session_expiry() {
     let mqtt::packet::Packet::V5_0Connect(packet) = packet else {
         panic!("expected v5 connect packet");
     };
-    let saw_session_expiry = packet.props().iter().any(|prop| matches!(
-        prop,
-        mqtt::packet::Property::SessionExpiryInterval(value) if value.val() == 3600
-    ));
+    let saw_session_expiry = packet.props().iter().any(|prop| {
+        matches!(
+            prop,
+            mqtt::packet::Property::SessionExpiryInterval(value) if value.val() == 3600
+        )
+    });
     assert!(saw_session_expiry);
 }
 
@@ -1282,7 +1339,10 @@ fn mqtt_listener_reconnects_after_broker_disconnect() {
         if !events.lock().expect("events lock").is_empty() {
             break;
         }
-        assert!(std::time::Instant::now() < deadline, "expected event after reconnect");
+        assert!(
+            std::time::Instant::now() < deadline,
+            "expected event after reconnect"
+        );
         thread::sleep(Duration::from_millis(TEST_EVENT_WAIT_POLL_MS));
     }
 
@@ -1401,8 +1461,7 @@ fn mqtt_same_driver_can_listen_and_control_subscriptions() {
     block_on(driver.start_listening(NoopSink)).expect("listener should start");
     block_on(driver.subscribe(subscribe_packet, NoopSink))
         .expect("same driver should subscribe while listening");
-    block_on(driver.publish(publish_packet))
-        .expect("same driver should publish while listening");
+    block_on(driver.publish(publish_packet)).expect("same driver should publish while listening");
     block_on(driver.unsubscribe(unsubscribe_packet))
         .expect("same driver should unsubscribe while listening");
 
@@ -1419,7 +1478,9 @@ fn mqtt_same_driver_can_listen_and_control_subscriptions() {
 #[test]
 fn mqtt_connect_auth_roundtrip_uses_handler_response() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
-    let addr = listener.local_addr().expect("test broker should have local addr");
+    let addr = listener
+        .local_addr()
+        .expect("test broker should have local addr");
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
 
     let broker_handle = thread::spawn(move || {
@@ -1428,7 +1489,8 @@ fn mqtt_connect_auth_roundtrip_uses_handler_response() {
             .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
             .expect("broker should set read timeout");
 
-        let mut connection = mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
+        let mut connection =
+            mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
 
         let connect = recv_server_packet(&mut stream, &mut connection);
         match connect {
@@ -1603,7 +1665,9 @@ fn mqtt_connect_auth_roundtrip_uses_handler_response() {
 #[test]
 fn mqtt_listener_handles_reauthentication_auth_packets() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
-    let addr = listener.local_addr().expect("test broker should have local addr");
+    let addr = listener
+        .local_addr()
+        .expect("test broker should have local addr");
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
     let (reauth_seen_tx, reauth_seen_rx) = mpsc::channel();
 
@@ -1613,7 +1677,8 @@ fn mqtt_listener_handles_reauthentication_auth_packets() {
             .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
             .expect("broker should set read timeout");
 
-        let mut connection = mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
+        let mut connection =
+            mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
 
         let connect = recv_server_packet(&mut stream, &mut connection);
         assert!(matches!(connect, mqtt::packet::Packet::V5_0Connect(_)));

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -1,9 +1,18 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    future::Future,
+    io::{Read, Write},
+    net::TcpListener,
+    sync::mpsc,
+    task::{Context, Poll, Waker},
+    thread,
+    time::Duration,
+};
 
 use ferredge_core::prelude::{
-    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions,
-    Correlation, Device, DeviceEndpoint, DeviceStatus, Map, MqttEndpointConfig,
-    MqttProtocolVersion, RoutedMessage,
+    Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions, BrokerSubscriptionOptions, EventSink,
+    EventSource, Correlation, Device, DeviceEndpoint, DeviceStatus, Lifecycle, Map,
+    MqttEndpointConfig, MqttProtocolVersion, RoutedEvent, RoutedMessage,
 };
 use mqtt_protocol_core::mqtt;
 
@@ -13,13 +22,13 @@ use crate::{
     MqttDriver, MqttListenerStatus,
 };
 
-fn make_driver(supported_versions: Vec<MqttProtocolVersion>) -> MqttDriver {
+fn make_driver(broker: String, supported_versions: Vec<MqttProtocolVersion>) -> MqttDriver {
     MqttDriver::new(Device {
         id: "mqtt-device-1".to_string(),
         name: "MQTT Device".to_string(),
         status: DeviceStatus::Online,
         endpoint: DeviceEndpoint::mqtt(MqttEndpointConfig {
-            broker: "mqtt://broker".to_string(),
+            broker,
             client_id: "client-1".to_string(),
             auth: None,
             tls: None,
@@ -36,9 +45,121 @@ fn make_driver(supported_versions: Vec<MqttProtocolVersion>) -> MqttDriver {
     })
 }
 
+fn make_default_driver() -> MqttDriver {
+    make_driver("mqtt://broker".to_string(), vec![MqttProtocolVersion::V5_0])
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    let mut future = std::pin::pin!(future);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => thread::yield_now(),
+        }
+    }
+}
+
+fn wait_for_status(
+    rx: &mpsc::Receiver<MqttListenerStatus>,
+    matcher: impl Fn(&MqttListenerStatus) -> bool,
+) -> MqttListenerStatus {
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        let timeout = deadline.saturating_duration_since(std::time::Instant::now());
+        let status = rx
+            .recv_timeout(timeout)
+            .expect("listener status should arrive before timeout");
+        if matcher(&status) {
+            return status;
+        }
+    }
+}
+
+fn spawn_test_broker_v5(
+    publish_after_connack: Option<mqtt::packet::v5_0::Publish>,
+) -> (String, mpsc::Sender<()>, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
+    let addr = listener.local_addr().expect("test broker should have local addr");
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("broker should accept client");
+        stream
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .expect("broker should set read timeout");
+
+        let mut connect_buffer = [0u8; 4096];
+        let _ = stream.read(&mut connect_buffer);
+
+        let connack = mqtt::packet::v5_0::Connack::builder()
+            .session_present(false)
+            .reason_code(mqtt::result_code::ConnectReasonCode::Success)
+            .props(Vec::new())
+            .build()
+            .expect("connack should build");
+        stream
+            .write_all(&connack.to_continuous_buffer())
+            .expect("broker should send connack");
+
+        if let Some(publish) = publish_after_connack {
+            thread::sleep(Duration::from_millis(150));
+            stream
+                .write_all(&publish.to_continuous_buffer())
+                .expect("broker should send publish");
+        }
+
+        loop {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+
+            let mut buffer = [0u8; 4096];
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    (format!("mqtt://{addr}"), shutdown_tx, handle)
+}
+
+struct NoopSink;
+
+impl EventSink for NoopSink {
+    type Event = RoutedEvent;
+    type Error = ();
+
+    fn handle(&mut self, _event: Self::Event) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+struct FailOnEventSink;
+
+impl EventSink for FailOnEventSink {
+    type Event = RoutedEvent;
+    type Error = ();
+
+    fn handle(&mut self, _event: Self::Event) -> Result<(), Self::Error> {
+        Err(())
+    }
+}
+
 #[test]
 fn mqtt_send_prefers_v5_packet_when_available() {
-    let driver = make_driver(vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0]);
+    let driver = make_driver(
+        "mqtt://broker".to_string(),
+        vec![MqttProtocolVersion::V3_1_1, MqttProtocolVersion::V5_0],
+    );
     let command = ferredge_core::prelude::Command {
         id: "cmd-1".to_string(),
         source_device_id: None,
@@ -71,7 +192,7 @@ fn mqtt_send_prefers_v5_packet_when_available() {
 
 #[test]
 fn mqtt_send_falls_back_to_v3_when_v5_not_available() {
-    let driver = make_driver(vec![MqttProtocolVersion::V3_1_1]);
+    let driver = make_driver("mqtt://broker".to_string(), vec![MqttProtocolVersion::V3_1_1]);
     let command = ferredge_core::prelude::Command {
         id: "cmd-2".to_string(),
         source_device_id: None,
@@ -99,7 +220,7 @@ fn mqtt_send_falls_back_to_v3_when_v5_not_available() {
 
 #[test]
 fn mqtt_subscribe_builds_version_specific_packet() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
     let command = ferredge_core::prelude::Command {
         id: "cmd-3".to_string(),
         source_device_id: None,
@@ -130,7 +251,7 @@ fn mqtt_subscribe_builds_version_specific_packet() {
 
 #[test]
 fn mqtt_v5_publish_maps_reply_and_correlation_properties() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
     let command = ferredge_core::prelude::Command {
         id: "cmd-4".to_string(),
         source_device_id: None,
@@ -228,7 +349,7 @@ fn inbound_publish_packet_converts_to_routed_event() {
 
 #[test]
 fn mqtt_listener_status_starts_stopped() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
 
     assert_eq!(
         driver.listener_status().expect("listener status should be readable"),
@@ -244,7 +365,7 @@ fn mqtt_listener_status_starts_stopped() {
 
 #[test]
 fn mqtt_listener_error_can_be_cleared_without_runtime() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
 
     driver
         .clear_listener_error()
@@ -257,7 +378,7 @@ fn mqtt_listener_error_can_be_cleared_without_runtime() {
 
 #[test]
 fn mqtt_listener_status_subscription_receives_initial_state() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
 
     let rx = driver
         .subscribe_listener_status()
@@ -271,7 +392,7 @@ fn mqtt_listener_status_subscription_receives_initial_state() {
 
 #[test]
 fn mqtt_listener_status_subscription_receives_clear_transition() {
-    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let driver = make_default_driver();
     let rx = driver
         .subscribe_listener_status()
         .expect("listener status subscription should succeed");
@@ -285,4 +406,75 @@ fn mqtt_listener_status_subscription_receives_clear_transition() {
         rx.recv().expect("listener status transition should be sent"),
         MqttListenerStatus::Stopped
     );
+}
+
+#[test]
+fn mqtt_listener_can_start_stop_and_restart() {
+    let (broker, shutdown_tx, broker_handle) = spawn_test_broker_v5(None);
+    let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
+    let rx = driver
+        .subscribe_listener_status()
+        .expect("listener status subscription should succeed");
+    let _ = rx.recv().expect("initial listener status should be sent");
+
+    block_on(driver.start_listening(NoopSink)).expect("listener should start");
+    assert_eq!(
+        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Running)),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop_listening()).expect("listener should stop");
+    assert_eq!(
+        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        MqttListenerStatus::Stopped
+    );
+
+    block_on(driver.start_listening(NoopSink)).expect("listener should restart");
+    assert_eq!(
+        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Running)),
+        MqttListenerStatus::Running
+    );
+
+    block_on(driver.stop()).expect("driver should stop cleanly");
+    assert!(matches!(
+        wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Stopped)),
+        MqttListenerStatus::Stopped
+    ));
+
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn mqtt_listener_reports_failed_when_sink_rejects_event() {
+    let publish = mqtt::packet::v5_0::Publish::builder()
+        .topic_name("alerts/test")
+        .expect("publish topic should be valid")
+        .payload("boom")
+        .build()
+        .expect("publish packet should build");
+    let (broker, shutdown_tx, broker_handle) = spawn_test_broker_v5(Some(publish));
+    let driver = make_driver(broker, vec![MqttProtocolVersion::V5_0]);
+    let rx = driver
+        .subscribe_listener_status()
+        .expect("listener status subscription should succeed");
+    let _ = rx.recv().expect("initial listener status should be sent");
+
+    block_on(driver.start_listening(FailOnEventSink)).expect("listener should start");
+    let failed = wait_for_status(&rx, |status| matches!(status, MqttListenerStatus::Failed(_)));
+    assert_eq!(
+        failed,
+        MqttListenerStatus::Failed("failed to forward MQTT event to sink".to_string())
+    );
+    assert_eq!(
+        driver
+            .last_listener_error()
+            .expect("listener error should be readable"),
+        Some("failed to forward MQTT event to sink".to_string())
+    );
+
+    block_on(driver.stop()).expect("driver should stop after failure");
+
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
 }

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -254,3 +254,35 @@ fn mqtt_listener_error_can_be_cleared_without_runtime() {
         MqttListenerStatus::Stopped
     );
 }
+
+#[test]
+fn mqtt_listener_status_subscription_receives_initial_state() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+
+    let rx = driver
+        .subscribe_listener_status()
+        .expect("listener status subscription should succeed");
+
+    assert_eq!(
+        rx.recv().expect("initial listener status should be sent"),
+        MqttListenerStatus::Stopped
+    );
+}
+
+#[test]
+fn mqtt_listener_status_subscription_receives_clear_transition() {
+    let driver = make_driver(vec![MqttProtocolVersion::V5_0]);
+    let rx = driver
+        .subscribe_listener_status()
+        .expect("listener status subscription should succeed");
+    let _ = rx.recv().expect("initial listener status should be sent");
+
+    driver
+        .clear_listener_error()
+        .expect("clearing empty listener error should succeed");
+
+    assert_eq!(
+        rx.recv().expect("listener status transition should be sent"),
+        MqttListenerStatus::Stopped
+    );
+}

--- a/crates/ferredge-proto-mqtt/src/tests.rs
+++ b/crates/ferredge-proto-mqtt/src/tests.rs
@@ -2,28 +2,32 @@ use std::{
     collections::HashMap,
     future::Future,
     io::{Read, Write},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
     sync::{Arc, Mutex, OnceLock, mpsc},
     thread,
     time::Duration,
 };
 
 use ferredge_core::prelude::{
-    ActionEmitter, Address, BrokerAddress, BrokerChannelKind, BrokerMessageOptions,
-    BrokerReconnectConfig, BrokerSubscriptionOptions, ChannelReceiver, Command, Correlation,
-    Device, DeviceEndpoint, DeviceStatus, EventSink, EventSource, HttpEndpointConfig, Intent,
-    Lifecycle, Map, MqttConnectProperties, MqttEndpointConfig, MqttProtocolVersion,
-    ProtocolBridge, PubSub, RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
-    AsyncRuntime,
+    ActionEmitter, Address, AsyncRuntime, BrokerAddress, BrokerChannelKind,
+    BrokerMessageOptions, BrokerMessageProtocolOptions, BrokerReconnectConfig,
+    BrokerSubscriptionOptions, BrokerSubscriptionProtocolOptions, ChannelReceiver, Command,
+    Correlation, DeliveryGuarantee, Device, DeviceEndpoint, DeviceStatus, EventSink,
+    EventSource, HttpEndpointConfig, Intent, Lifecycle, Map, MqttConnectProperties,
+    MqttEndpointConfig, MqttMessageOptions, MqttPayloadFormat, MqttProtocolVersion,
+    MqttRetainHandling, MqttSubscriptionOptions, MqttWillConfig, ProtocolBridge, PubSub,
+    RoutedEvent, RoutedMessage, RoutedResult, TransportMeta,
 };
 use mqtt_protocol_core::mqtt;
+use mqtt_protocol_core::mqtt::packet::GenericPacketTrait;
 use ferredge_proto_http::{attributes::HttpResourceAttributes, HttpCommandRef, HttpDriver, HttpRequest};
 
 use crate::{
     runtime_stack::StackRuntime,
     runtime::{build_connect_packet, normalize_broker_addr, routed_message_from_packet},
     types::{MqttCommandRef, MqttPacketRequest, MqttWirePacket},
-    MqttDriver, MqttListenerStatus,
+    MqttAuthChallenge, MqttAuthFlowReason, MqttAuthResponse, MqttAuthStage, MqttDriver,
+    MqttListenerStatus,
 };
 
 type RuntimeReceiver<T> = <StackRuntime as AsyncRuntime>::Receiver<T>;
@@ -49,6 +53,7 @@ fn make_driver(broker: String, supported_versions: Vec<MqttProtocolVersion>) -> 
             session_expiry_secs: None,
             topic_prefix: Some("ferredge".to_string()),
             connect_properties: MqttConnectProperties::default(),
+            will: None,
             reconnect: BrokerReconnectConfig::default(),
             supported_versions,
         }),
@@ -263,6 +268,52 @@ fn spawn_keepalive_test_broker_v5() -> (String, mpsc::Sender<()>, thread::JoinHa
     (format!("mqtt://{addr}"), shutdown_tx, handle)
 }
 
+fn recv_server_packet(
+    stream: &mut TcpStream,
+    connection: &mut mqtt::Connection<mqtt::role::Server>,
+) -> mqtt::packet::Packet {
+    let deadline = std::time::Instant::now() + Duration::from_secs(TEST_STATUS_TIMEOUT_SECS);
+    loop {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "broker should receive MQTT packet before timeout"
+        );
+        let mut buffer = [0u8; 4096];
+        match stream.read(&mut buffer) {
+            Ok(0) => panic!("client closed before expected MQTT packet"),
+            Ok(n) => {
+                let events = connection.recv(&mut mqtt::common::Cursor::new(&buffer[..n]));
+                for event in events {
+                    if let mqtt::connection::Event::NotifyPacketReceived(packet) = event {
+                        return packet;
+                    }
+                }
+            }
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(error) => panic!("broker read failed: {error}"),
+        }
+    }
+}
+
+fn send_server_packet(
+    stream: &mut TcpStream,
+    connection: &mut mqtt::Connection<mqtt::role::Server>,
+    packet: mqtt::packet::Packet,
+) {
+    let events = connection.checked_send(packet);
+    for event in events {
+        if let mqtt::connection::Event::RequestSendPacket { packet, .. } = event {
+            stream
+                .write_all(&packet.to_continuous_buffer())
+                .expect("broker should send MQTT packet");
+        }
+    }
+}
+
 struct NoopSink;
 
 impl EventSink for NoopSink {
@@ -415,9 +466,7 @@ fn mqtt_send_prefers_v5_packet_when_available() {
             payload: b"42".to_vec(),
             options: BrokerMessageOptions {
                 delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
-                headers: Vec::new(),
-                reply_to: None,
-                correlation_id: None,
+                ..BrokerMessageOptions::default()
             },
         },
         correlation: None,
@@ -477,6 +526,16 @@ fn mqtt_subscribe_builds_version_specific_packet() {
                 delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
                 durable_name: Some("durable-a".to_string()),
                 shared_group: Some("shared-a".to_string()),
+                protocol: Some(BrokerSubscriptionProtocolOptions::Mqtt(
+                    MqttSubscriptionOptions {
+                        no_local: true,
+                        retain_as_published: true,
+                        retain_handling: Some(MqttRetainHandling::DoNotSendRetained),
+                        subscription_identifier: Some(7),
+                        ..MqttSubscriptionOptions::default()
+                    },
+                )),
+                ..BrokerSubscriptionOptions::default()
             },
         },
         correlation: None,
@@ -492,29 +551,78 @@ fn mqtt_subscribe_builds_version_specific_packet() {
     match packet.packet {
         MqttWirePacket::V5Subscribe(packet) => {
             let mut saw_subscription_identifier = false;
-            let mut saw_durable = false;
-            let mut saw_shared = false;
+            assert_eq!(packet.entries()[0].topic_filter(), "$share/shared-a/alerts/#");
+            assert!(packet.entries()[0].sub_opts().nl());
+            assert!(packet.entries()[0].sub_opts().rap());
+            assert_eq!(
+                packet.entries()[0].sub_opts().rh(),
+                mqtt::packet::RetainHandling::DoNotSendRetained
+            );
             for prop in packet.props() {
                 match prop {
                     mqtt::packet::Property::SubscriptionIdentifier(prop) => {
-                        saw_subscription_identifier = prop.val() == 1;
-                    }
-                    mqtt::packet::Property::UserProperty(prop) => {
-                        if prop.key() == "ferredge-durable-name" && prop.val() == "durable-a" {
-                            saw_durable = true;
-                        }
-                        if prop.key() == "ferredge-shared-group" && prop.val() == "shared-a" {
-                            saw_shared = true;
-                        }
+                        saw_subscription_identifier = prop.val() == 7;
                     }
                     _ => {}
                 }
             }
             assert!(saw_subscription_identifier);
-            assert!(saw_durable);
-            assert!(saw_shared);
         }
         other => panic!("expected v5 subscribe packet, got {other:?}"),
+    }
+}
+
+#[test]
+fn mqtt_v5_publish_maps_retain_alias_and_expiry_properties() {
+    let driver = make_default_driver();
+    let command = ferredge_core::prelude::Command {
+        id: "cmd-retain-1".to_string(),
+        source_device_id: None,
+        target_device_id: "mqtt-device-1".to_string(),
+        intent: ferredge_core::prelude::Intent::Send {
+            channel: BrokerAddress {
+                name: "state/device".to_string(),
+                kind: Some(BrokerChannelKind::Topic),
+            },
+            payload: b"online".to_vec(),
+            options: BrokerMessageOptions {
+                delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
+                protocol: Some(BrokerMessageProtocolOptions::Mqtt(MqttMessageOptions {
+                    retain: true,
+                    payload_format: Some(MqttPayloadFormat::Utf8),
+                    message_expiry_interval_secs: Some(30),
+                    topic_alias: Some(4),
+                    ..MqttMessageOptions::default()
+                })),
+                ..BrokerMessageOptions::default()
+            },
+        },
+        correlation: None,
+    };
+
+    let packet = MqttPacketRequest::try_from(MqttCommandRef {
+        device: &driver.dvc,
+        command: &command,
+    })
+    .expect("v5 publish should build");
+
+    match packet.packet {
+        MqttWirePacket::V5Publish(packet) => {
+            assert!(packet.retain());
+            assert!(packet.props().iter().any(|prop| matches!(
+                prop,
+                mqtt::packet::Property::PayloadFormatIndicator(value) if value.val() == 1
+            )));
+            assert!(packet.props().iter().any(|prop| matches!(
+                prop,
+                mqtt::packet::Property::MessageExpiryInterval(value) if value.val() == 30
+            )));
+            assert!(packet.props().iter().any(|prop| matches!(
+                prop,
+                mqtt::packet::Property::TopicAlias(value) if value.val() == 4
+            )));
+        }
+        other => panic!("expected v5 publish packet, got {other:?}"),
     }
 }
 
@@ -579,9 +687,13 @@ fn mqtt_v5_publish_maps_reply_and_correlation_properties() {
             payload: b"{}".to_vec(),
             options: BrokerMessageOptions {
                 delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
-                headers: vec![("content-type".to_string(), "application/json".to_string())],
                 reply_to: Some("rpc/reply".to_string()),
                 correlation_id: Some("corr-123".to_string()),
+                protocol: Some(BrokerMessageProtocolOptions::Mqtt(MqttMessageOptions {
+                    content_type: Some("application/json".to_string()),
+                    ..MqttMessageOptions::default()
+                })),
+                ..BrokerMessageOptions::default()
             },
         },
         correlation: None,
@@ -635,9 +747,8 @@ fn mqtt_v5_publish_uses_command_id_as_correlation_when_reply_topic_present() {
             payload: b"{}".to_vec(),
             options: BrokerMessageOptions {
                 delivery: Some(ferredge_core::prelude::DeliveryGuarantee::AtLeastOnce),
-                headers: Vec::new(),
                 reply_to: Some("rpc/reply".to_string()),
-                correlation_id: None,
+                ..BrokerMessageOptions::default()
             },
         },
         correlation: None,
@@ -1086,6 +1197,7 @@ fn mqtt_connect_packet_maps_v5_session_expiry() {
         session_expiry_secs: Some(3600),
         topic_prefix: None,
         connect_properties: MqttConnectProperties::default(),
+        will: None,
         reconnect: BrokerReconnectConfig::default(),
         supported_versions: vec![MqttProtocolVersion::V5_0],
     })
@@ -1099,6 +1211,53 @@ fn mqtt_connect_packet_maps_v5_session_expiry() {
         mqtt::packet::Property::SessionExpiryInterval(value) if value.val() == 3600
     ));
     assert!(saw_session_expiry);
+}
+
+#[test]
+fn mqtt_connect_packet_maps_v5_will_properties() {
+    let packet = build_connect_packet(&MqttEndpointConfig {
+        broker: "mqtt://broker".to_string(),
+        client_id: "client-with-will".to_string(),
+        auth: None,
+        tls: None,
+        keepalive_secs: Some(30),
+        clean_start: true,
+        session_expiry_secs: None,
+        topic_prefix: None,
+        connect_properties: MqttConnectProperties::default(),
+        will: Some(MqttWillConfig {
+            topic: "status/offline".to_string(),
+            payload: b"offline".to_vec(),
+            delivery: Some(DeliveryGuarantee::AtLeastOnce),
+            retain: true,
+            delay_interval_secs: Some(5),
+            payload_format: Some(MqttPayloadFormat::Utf8),
+            message_expiry_interval_secs: Some(60),
+            content_type: Some("text/plain".to_string()),
+            response_topic: Some("status/reply".to_string()),
+            correlation_data: Some(b"will-corr".to_vec()),
+            user_properties: vec![("source".to_string(), "ferredge".to_string())],
+        }),
+        reconnect: BrokerReconnectConfig::default(),
+        supported_versions: vec![MqttProtocolVersion::V5_0],
+    })
+    .expect("connect packet should build");
+
+    let mqtt::packet::Packet::V5_0Connect(packet) = packet else {
+        panic!("expected v5 connect packet");
+    };
+    assert!(packet.will_flag());
+    assert_eq!(packet.will_topic(), Some("status/offline"));
+    assert_eq!(packet.will_payload(), Some(&b"offline"[..]));
+    assert!(packet.will_retain());
+    assert!(packet.will_props().iter().any(|prop| matches!(
+        prop,
+        mqtt::packet::Property::WillDelayInterval(value) if value.val() == 5
+    )));
+    assert!(packet.will_props().iter().any(|prop| matches!(
+        prop,
+        mqtt::packet::Property::MessageExpiryInterval(value) if value.val() == 60
+    )));
 }
 
 #[test]
@@ -1158,6 +1317,7 @@ fn mqtt_listener_keeps_running_with_ping_response() {
             session_expiry_secs: None,
             topic_prefix: None,
             connect_properties: MqttConnectProperties::default(),
+            will: None,
             reconnect: BrokerReconnectConfig::default(),
             supported_versions: vec![MqttProtocolVersion::V5_0],
         }),
@@ -1252,6 +1412,318 @@ fn mqtt_same_driver_can_listen_and_control_subscriptions() {
     );
 
     block_on(driver.stop()).expect("driver should stop after same-driver control test");
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn mqtt_connect_auth_roundtrip_uses_handler_response() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
+    let addr = listener.local_addr().expect("test broker should have local addr");
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+
+    let broker_handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("broker should accept client");
+        stream
+            .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
+            .expect("broker should set read timeout");
+
+        let mut connection = mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
+
+        let connect = recv_server_packet(&mut stream, &mut connection);
+        match connect {
+            mqtt::packet::Packet::V5_0Connect(packet) => {
+                let mut authentication_method = None;
+                let mut authentication_data = None;
+                for prop in packet.props() {
+                    match prop {
+                        mqtt::packet::Property::AuthenticationMethod(prop) => {
+                            authentication_method = Some(prop.val().to_string());
+                        }
+                        mqtt::packet::Property::AuthenticationData(prop) => {
+                            authentication_data = Some(prop.val().to_vec());
+                        }
+                        _ => {}
+                    }
+                }
+                assert_eq!(authentication_method.as_deref(), Some("scram-sha-256"));
+                assert_eq!(authentication_data, Some(b"client-first".to_vec()));
+            }
+            other => panic!("expected v5 connect packet, got {other:?}"),
+        }
+
+        let auth = mqtt::packet::v5_0::Auth::builder()
+            .reason_code(mqtt::result_code::AuthReasonCode::ContinueAuthentication)
+            .props(vec![
+                mqtt::packet::Property::AuthenticationMethod(
+                    mqtt::packet::AuthenticationMethod::new("scram-sha-256")
+                        .expect("auth method should build"),
+                ),
+                mqtt::packet::Property::AuthenticationData(
+                    mqtt::packet::AuthenticationData::new(b"server-first".to_vec())
+                        .expect("auth data should build"),
+                ),
+                mqtt::packet::Property::ReasonString(
+                    mqtt::packet::ReasonString::new("challenge")
+                        .expect("reason string should build"),
+                ),
+                mqtt::packet::Property::UserProperty(
+                    mqtt::packet::UserProperty::new("step", "1")
+                        .expect("user property should build"),
+                ),
+            ])
+            .build()
+            .expect("auth should build");
+        send_server_packet(&mut stream, &mut connection, auth.into());
+
+        let auth_response = recv_server_packet(&mut stream, &mut connection);
+        match auth_response {
+            mqtt::packet::Packet::V5_0Auth(packet) => {
+                assert_eq!(
+                    packet.reason_code(),
+                    Some(mqtt::result_code::AuthReasonCode::Success)
+                );
+                let mut authentication_method = None;
+                let mut authentication_data = None;
+                let mut reason_string = None;
+                let mut user_property = None;
+                if let Some(props) = packet.props() {
+                    for prop in props {
+                        match prop {
+                            mqtt::packet::Property::AuthenticationMethod(prop) => {
+                                authentication_method = Some(prop.val().to_string());
+                            }
+                            mqtt::packet::Property::AuthenticationData(prop) => {
+                                authentication_data = Some(prop.val().to_vec());
+                            }
+                            mqtt::packet::Property::ReasonString(prop) => {
+                                reason_string = Some(prop.val().to_string());
+                            }
+                            mqtt::packet::Property::UserProperty(prop) => {
+                                user_property =
+                                    Some((prop.key().to_string(), prop.val().to_string()));
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                assert_eq!(authentication_method.as_deref(), Some("scram-sha-256"));
+                assert_eq!(authentication_data, Some(b"client-final".to_vec()));
+                assert_eq!(reason_string.as_deref(), Some("proof"));
+                assert_eq!(
+                    user_property,
+                    Some(("client-step".to_string(), "2".to_string()))
+                );
+            }
+            other => panic!("expected v5 auth packet, got {other:?}"),
+        }
+
+        let connack = mqtt::packet::v5_0::Connack::builder()
+            .session_present(false)
+            .reason_code(mqtt::result_code::ConnectReasonCode::Success)
+            .props(vec![mqtt::packet::Property::AuthenticationMethod(
+                mqtt::packet::AuthenticationMethod::new("scram-sha-256")
+                    .expect("auth method should build"),
+            )])
+            .build()
+            .expect("connack should build");
+        send_server_packet(&mut stream, &mut connection, connack.into());
+
+        loop {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+            let mut buffer = [0u8; 4096];
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut driver = make_driver(format!("mqtt://{addr}"), vec![MqttProtocolVersion::V5_0]);
+    let seen_challenges = Arc::new(Mutex::new(Vec::new()));
+    if let DeviceEndpoint::Mqtt(config) = &mut driver.dvc.endpoint {
+        config.connect_properties.authentication_method = Some("scram-sha-256".to_string());
+        config.connect_properties.authentication_data = Some(b"client-first".to_vec());
+    }
+    {
+        let seen_challenges = Arc::clone(&seen_challenges);
+        driver
+            .set_auth_handler(move |challenge: MqttAuthChallenge| {
+                seen_challenges
+                    .lock()
+                    .expect("seen challenge lock")
+                    .push(challenge.clone());
+                Ok(Some(MqttAuthResponse {
+                    reason: MqttAuthFlowReason::Success,
+                    authentication_method: None,
+                    authentication_data: Some(b"client-final".to_vec()),
+                    reason_string: Some("proof".to_string()),
+                    user_properties: vec![("client-step".to_string(), "2".to_string())],
+                }))
+            })
+            .expect("auth handler should register");
+    }
+
+    block_on(driver.start()).expect("driver should finish auth handshake");
+    block_on(driver.stop()).expect("driver should stop cleanly after auth handshake");
+
+    let challenges = seen_challenges.lock().expect("seen challenge lock");
+    assert_eq!(challenges.len(), 1);
+    assert_eq!(challenges[0].stage, MqttAuthStage::Connect);
+    assert_eq!(
+        challenges[0].reason,
+        MqttAuthFlowReason::ContinueAuthentication
+    );
+    assert_eq!(
+        challenges[0].authentication_method.as_deref(),
+        Some("scram-sha-256")
+    );
+    assert_eq!(
+        challenges[0].authentication_data,
+        Some(b"server-first".to_vec())
+    );
+    assert_eq!(challenges[0].reason_string.as_deref(), Some("challenge"));
+    assert_eq!(
+        challenges[0].user_properties,
+        vec![("step".to_string(), "1".to_string())]
+    );
+
+    let _ = shutdown_tx.send(());
+    broker_handle.join().expect("broker thread should join");
+}
+
+#[test]
+fn mqtt_listener_handles_reauthentication_auth_packets() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test broker should bind");
+    let addr = listener.local_addr().expect("test broker should have local addr");
+    let (shutdown_tx, shutdown_rx) = mpsc::channel();
+    let (reauth_seen_tx, reauth_seen_rx) = mpsc::channel();
+
+    let broker_handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("broker should accept client");
+        stream
+            .set_read_timeout(Some(Duration::from_millis(TEST_BROKER_READ_TIMEOUT_MS)))
+            .expect("broker should set read timeout");
+
+        let mut connection = mqtt::Connection::<mqtt::role::Server>::new(mqtt::Version::Undetermined);
+
+        let connect = recv_server_packet(&mut stream, &mut connection);
+        assert!(matches!(connect, mqtt::packet::Packet::V5_0Connect(_)));
+
+        let connack = mqtt::packet::v5_0::Connack::builder()
+            .session_present(false)
+            .reason_code(mqtt::result_code::ConnectReasonCode::Success)
+            .build()
+            .expect("connack should build");
+        send_server_packet(&mut stream, &mut connection, connack.into());
+
+        let reauth = mqtt::packet::v5_0::Auth::builder()
+            .reason_code(mqtt::result_code::AuthReasonCode::ReAuthenticate)
+            .props(vec![
+                mqtt::packet::Property::AuthenticationMethod(
+                    mqtt::packet::AuthenticationMethod::new("scram-sha-256")
+                        .expect("auth method should build"),
+                ),
+                mqtt::packet::Property::AuthenticationData(
+                    mqtt::packet::AuthenticationData::new(b"server-reauth".to_vec())
+                        .expect("auth data should build"),
+                ),
+            ])
+            .build()
+            .expect("reauth should build");
+        send_server_packet(&mut stream, &mut connection, reauth.into());
+
+        let auth_response = recv_server_packet(&mut stream, &mut connection);
+        match auth_response {
+            mqtt::packet::Packet::V5_0Auth(packet) => {
+                assert_eq!(
+                    packet.reason_code(),
+                    Some(mqtt::result_code::AuthReasonCode::Success)
+                );
+                let mut authentication_data = None;
+                if let Some(props) = packet.props() {
+                    for prop in props {
+                        if let mqtt::packet::Property::AuthenticationData(prop) = prop {
+                            authentication_data = Some(prop.val().to_vec());
+                        }
+                    }
+                }
+                assert_eq!(authentication_data, Some(b"client-reauth".to_vec()));
+                reauth_seen_tx
+                    .send(())
+                    .expect("reauth completion should signal test");
+            }
+            other => panic!("expected v5 auth packet, got {other:?}"),
+        }
+
+        loop {
+            if shutdown_rx.try_recv().is_ok() {
+                break;
+            }
+            let mut buffer = [0u8; 4096];
+            match stream.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut driver = make_driver(format!("mqtt://{addr}"), vec![MqttProtocolVersion::V5_0]);
+    let seen_challenges = Arc::new(Mutex::new(Vec::new()));
+    if let DeviceEndpoint::Mqtt(config) = &mut driver.dvc.endpoint {
+        config.connect_properties.authentication_method = Some("scram-sha-256".to_string());
+    }
+    {
+        let seen_challenges = Arc::clone(&seen_challenges);
+        driver
+            .set_auth_handler(move |challenge: MqttAuthChallenge| {
+                seen_challenges
+                    .lock()
+                    .expect("seen challenge lock")
+                    .push(challenge.clone());
+                Ok(Some(MqttAuthResponse {
+                    reason: MqttAuthFlowReason::Success,
+                    authentication_method: None,
+                    authentication_data: Some(match challenge.stage {
+                        MqttAuthStage::Connect => b"client-connect".to_vec(),
+                        MqttAuthStage::Reauthenticate => b"client-reauth".to_vec(),
+                    }),
+                    reason_string: None,
+                    user_properties: Vec::new(),
+                }))
+            })
+            .expect("auth handler should register");
+    }
+
+    block_on(driver.start_listening(NoopSink)).expect("listener should start");
+    reauth_seen_rx
+        .recv_timeout(Duration::from_secs(TEST_STATUS_TIMEOUT_SECS))
+        .expect("broker should receive reauth response");
+    block_on(driver.stop()).expect("driver should stop cleanly after reauth");
+
+    let challenges = seen_challenges.lock().expect("seen challenge lock");
+    assert_eq!(challenges.len(), 1);
+    assert_eq!(challenges[0].stage, MqttAuthStage::Reauthenticate);
+    assert_eq!(challenges[0].reason, MqttAuthFlowReason::ReAuthenticate);
+    assert_eq!(
+        challenges[0].authentication_data,
+        Some(b"server-reauth".to_vec())
+    );
+
     let _ = shutdown_tx.send(());
     broker_handle.join().expect("broker thread should join");
 }

--- a/crates/ferredge-proto-mqtt/src/types.rs
+++ b/crates/ferredge-proto-mqtt/src/types.rs
@@ -1,11 +1,4 @@
-#[cfg(not(feature = "std"))]
 extern crate alloc;
-
-#[cfg(feature = "std")]
-use std::{
-    string::{String, ToString},
-    vec::Vec,
-};
 
 #[cfg(not(feature = "std"))]
 use alloc::{
@@ -34,12 +27,28 @@ pub struct MqttPublishRequest {
     pub payload: Vec<u8>,
     /// Delivery guarantee requested by routed command.
     pub delivery: Option<DeliveryGuarantee>,
+    /// Whether broker should retain message.
+    pub retain: bool,
+    /// Optional MQTT v5 payload format indicator.
+    pub payload_format: Option<MqttPayloadFormat>,
+    /// Optional MQTT v5 content type.
+    pub content_type: Option<String>,
+    /// Optional MQTT v5 message expiry interval in seconds.
+    pub message_expiry_interval_secs: Option<u32>,
+    /// Optional MQTT v5 topic alias.
+    pub topic_alias: Option<u16>,
     /// Optional message headers for future v5 property mapping.
     pub headers: Vec<(String, String)>,
+    /// Optional MQTT v5 user properties.
+    pub user_properties: Vec<(String, String)>,
     /// Optional logical reply channel.
     pub reply_to: Option<String>,
+    /// Optional MQTT v5 response topic.
+    pub response_topic: Option<String>,
     /// Optional application-level correlation identifier.
     pub correlation_id: Option<String>,
+    /// Optional raw MQTT v5 correlation data.
+    pub correlation_data: Option<Vec<u8>>,
 }
 
 /// Native MQTT subscription request understood by adapter conversion layer.
@@ -55,6 +64,16 @@ pub struct MqttSubscriptionRequest {
     pub durable_name: Option<String>,
     /// Optional shared consumer group for brokers that support it.
     pub shared_group: Option<String>,
+    /// Prevent broker from sending local publishes back to this client.
+    pub no_local: bool,
+    /// Preserve original retain flag from broker publish.
+    pub retain_as_published: bool,
+    /// Retained publish handling policy at subscribe time.
+    pub retain_handling: Option<MqttRetainHandling>,
+    /// Optional MQTT v5 subscription identifier.
+    pub subscription_identifier: Option<u32>,
+    /// Optional MQTT v5 user properties.
+    pub user_properties: Vec<(String, String)>,
 }
 
 /// Version-aware MQTT native request produced from routed commands.
@@ -127,5 +146,78 @@ impl MqttCommandRef<'_> {
                 "device endpoint is not MQTT".to_string(),
             )),
         }
+    }
+}
+
+/// Stage of MQTT v5 enhanced authentication exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqttAuthStage {
+    /// Initial connect-time enhanced authentication.
+    Connect,
+    /// Re-authentication on already connected session.
+    Reauthenticate,
+}
+
+/// MQTT v5 enhanced authentication reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MqttAuthFlowReason {
+    /// Authentication exchange completed successfully.
+    Success,
+    /// Broker or client requests next auth step.
+    ContinueAuthentication,
+    /// Re-authentication initiated on live connection.
+    ReAuthenticate,
+}
+
+/// Inbound MQTT v5 auth challenge presented to auth handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MqttAuthChallenge {
+    /// Whether auth belongs to initial connect or later re-authentication.
+    pub stage: MqttAuthStage,
+    /// Packet reason for current auth exchange.
+    pub reason: MqttAuthFlowReason,
+    /// Authentication method selected for exchange.
+    pub authentication_method: Option<String>,
+    /// Authentication data bytes from broker.
+    pub authentication_data: Option<Vec<u8>>,
+    /// Optional human-readable reason string from broker.
+    pub reason_string: Option<String>,
+    /// Optional user properties from broker auth packet.
+    pub user_properties: Vec<(String, String)>,
+}
+
+/// Outbound MQTT v5 auth response returned by auth handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MqttAuthResponse {
+    /// Reason code to send in outgoing AUTH packet.
+    pub reason: MqttAuthFlowReason,
+    /// Authentication method to include. If omitted, current session method is reused.
+    pub authentication_method: Option<String>,
+    /// Authentication data bytes to send.
+    pub authentication_data: Option<Vec<u8>>,
+    /// Optional human-readable reason string.
+    pub reason_string: Option<String>,
+    /// Optional user properties.
+    pub user_properties: Vec<(String, String)>,
+}
+
+/// Provider for MQTT v5 enhanced authentication steps.
+pub trait MqttAuthProvider: Send + Sync {
+    /// Builds next auth response for broker challenge.
+    fn respond(
+        &self,
+        challenge: MqttAuthChallenge,
+    ) -> Result<Option<MqttAuthResponse>, String>;
+}
+
+impl<F> MqttAuthProvider for F
+where
+    F: Fn(MqttAuthChallenge) -> Result<Option<MqttAuthResponse>, String> + Send + Sync,
+{
+    fn respond(
+        &self,
+        challenge: MqttAuthChallenge,
+    ) -> Result<Option<MqttAuthResponse>, String> {
+        self(challenge)
     }
 }

--- a/crates/ferredge-proto-mqtt/src/types.rs
+++ b/crates/ferredge-proto-mqtt/src/types.rs
@@ -1,0 +1,125 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use std::{string::String, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use ferredge_core::prelude::*;
+use mqtt_protocol_core::mqtt;
+use serde::{Deserialize, Serialize};
+
+/// MQTT-specific resource metadata placeholder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct MqttResourceAttributes;
+
+impl DeviceResourceAttributes for MqttResourceAttributes {}
+
+/// Native MQTT publish request understood by adapter conversion layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MqttPublishRequest {
+    /// Original routed command identifier.
+    pub command_id: String,
+    /// Broker channel derived from routed command.
+    pub channel: BrokerAddress,
+    /// Raw message payload.
+    pub payload: Vec<u8>,
+    /// Delivery guarantee requested by routed command.
+    pub delivery: Option<DeliveryGuarantee>,
+    /// Optional message headers for future v5 property mapping.
+    pub headers: Vec<(String, String)>,
+    /// Optional logical reply channel.
+    pub reply_to: Option<String>,
+    /// Optional application-level correlation identifier.
+    pub correlation_id: Option<String>,
+}
+
+/// Native MQTT subscription request understood by adapter conversion layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MqttSubscriptionRequest {
+    /// Original routed command identifier.
+    pub command_id: String,
+    /// Broker channel to subscribe to.
+    pub channel: BrokerAddress,
+    /// Delivery guarantee requested by routed command.
+    pub delivery: Option<DeliveryGuarantee>,
+    /// Optional durable name for brokers that support it.
+    pub durable_name: Option<String>,
+    /// Optional shared consumer group for brokers that support it.
+    pub shared_group: Option<String>,
+}
+
+/// Version-aware MQTT native request produced from routed commands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MqttWirePacket {
+    /// MQTT publish packet serialized through MQTT 5.0 rules.
+    V5Publish(mqtt::packet::v5_0::Publish),
+    /// MQTT publish packet serialized through MQTT 3.1.1 rules.
+    V3Publish(mqtt::packet::v3_1_1::Publish),
+    /// MQTT subscribe packet serialized through MQTT 5.0 rules.
+    V5Subscribe(mqtt::packet::v5_0::Subscribe),
+    /// MQTT subscribe packet serialized through MQTT 3.1.1 rules.
+    V3Subscribe(mqtt::packet::v3_1_1::Subscribe),
+    /// MQTT unsubscribe packet serialized through MQTT 5.0 rules.
+    V5Unsubscribe(mqtt::packet::v5_0::Unsubscribe),
+    /// MQTT unsubscribe packet serialized through MQTT 3.1.1 rules.
+    V3Unsubscribe(mqtt::packet::v3_1_1::Unsubscribe),
+}
+
+/// Version-aware MQTT request plus original command identity for correlation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MqttPacketRequest {
+    /// Original routed command identifier.
+    pub command_id: String,
+    /// Concrete MQTT packet to send.
+    pub packet: MqttWirePacket,
+}
+
+/// MQTT conversion errors raised while projecting routed commands into MQTT packets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MqttCommandConversionError {
+    /// Routed command intent does not map to MQTT pub/sub semantics.
+    UnsupportedIntent,
+    /// Requested broker channel kind cannot be mapped to MQTT topic semantics.
+    UnsupportedChannelKind,
+    /// Routed command omitted packet details required for selected MQTT operation.
+    InvalidCommand(String),
+    /// Underlying `mqtt_protocol_core` packet builder rejected the request.
+    PacketBuild(String),
+}
+
+impl core::fmt::Display for MqttCommandConversionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::UnsupportedIntent => write!(f, "unsupported intent for MQTT driver"),
+            Self::UnsupportedChannelKind => {
+                write!(f, "unsupported broker channel kind for MQTT topic mapping")
+            }
+            Self::InvalidCommand(message) => write!(f, "{message}"),
+            Self::PacketBuild(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+/// Borrowed view carrying enough context to convert routed command into MQTT packets.
+#[derive(Debug, Clone, Copy)]
+pub struct MqttCommandRef<'a> {
+    /// Device-side broker configuration and metadata.
+    pub device: &'a Device<MqttResourceAttributes>,
+    /// Routed command to convert.
+    pub command: &'a Command,
+}
+
+impl MqttCommandRef<'_> {
+    /// Returns MQTT endpoint config from bound device.
+    pub fn endpoint_config(&self) -> Result<&MqttEndpointConfig, MqttCommandConversionError> {
+        match &self.device.endpoint {
+            DeviceEndpoint::Mqtt(config) => Ok(config),
+            _ => Err(MqttCommandConversionError::InvalidCommand(
+                "device endpoint is not MQTT".to_string(),
+            )),
+        }
+    }
+}

--- a/crates/ferredge-proto-mqtt/src/types.rs
+++ b/crates/ferredge-proto-mqtt/src/types.rs
@@ -204,20 +204,14 @@ pub struct MqttAuthResponse {
 /// Provider for MQTT v5 enhanced authentication steps.
 pub trait MqttAuthProvider: Send + Sync {
     /// Builds next auth response for broker challenge.
-    fn respond(
-        &self,
-        challenge: MqttAuthChallenge,
-    ) -> Result<Option<MqttAuthResponse>, String>;
+    fn respond(&self, challenge: MqttAuthChallenge) -> Result<Option<MqttAuthResponse>, String>;
 }
 
 impl<F> MqttAuthProvider for F
 where
     F: Fn(MqttAuthChallenge) -> Result<Option<MqttAuthResponse>, String> + Send + Sync,
 {
-    fn respond(
-        &self,
-        challenge: MqttAuthChallenge,
-    ) -> Result<Option<MqttAuthResponse>, String> {
+    fn respond(&self, challenge: MqttAuthChallenge) -> Result<Option<MqttAuthResponse>, String> {
         self(challenge)
     }
 }

--- a/crates/ferredge-proto-mqtt/src/types.rs
+++ b/crates/ferredge-proto-mqtt/src/types.rs
@@ -2,10 +2,16 @@
 extern crate alloc;
 
 #[cfg(feature = "std")]
-use std::{string::String, vec::Vec};
+use std::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use ferredge_core::prelude::*;
 use mqtt_protocol_core::mqtt;

--- a/crates/ferredge-runtime-async-std/Cargo.toml
+++ b/crates/ferredge-runtime-async-std/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ferredge-runtime-async-std"
+description = "async-std runtime and network adapters for ferredge core traits"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ferredge-core = { workspace = true, features = ["std"] }
+async-std = { workspace = true }

--- a/crates/ferredge-runtime-async-std/src/lib.rs
+++ b/crates/ferredge-runtime-async-std/src/lib.rs
@@ -92,6 +92,14 @@ where
     async fn recv(&mut self) -> Result<T, ChannelError> {
         self.inner.recv().await.map_err(|_| ChannelError::Closed)
     }
+
+    fn try_recv(&mut self) -> Result<T, ChannelError> {
+        match self.inner.try_recv() {
+            Ok(item) => Ok(item),
+            Err(async_std::channel::TryRecvError::Empty) => Err(ChannelError::Empty),
+            Err(async_std::channel::TryRecvError::Closed) => Err(ChannelError::Closed),
+        }
+    }
 }
 
 impl AsyncRuntime for AsyncStdRuntime {

--- a/crates/ferredge-runtime-async-std/src/lib.rs
+++ b/crates/ferredge-runtime-async-std/src/lib.rs
@@ -1,0 +1,230 @@
+use std::time::Duration;
+
+use async_std::{
+    io::{ReadExt, WriteExt},
+    net::{TcpListener, TcpStream},
+    task::{self, JoinHandle},
+};
+use ferredge_core::prelude::*;
+
+#[derive(Debug, Clone, Default)]
+pub struct AsyncStdRuntime;
+
+#[derive(Debug, Clone, Default)]
+pub struct AsyncStdNet;
+
+pub struct AsyncStdTask<T> {
+    handle: JoinHandle<T>,
+}
+
+pub struct AsyncStdSender<T> {
+    inner: async_std::channel::Sender<T>,
+}
+
+pub struct AsyncStdReceiver<T> {
+    inner: async_std::channel::Receiver<T>,
+}
+
+impl<T> Clone for AsyncStdSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct AsyncStdSocket {
+    stream: TcpStream,
+    read_timeout: Option<Duration>,
+    write_timeout: Option<Duration>,
+}
+
+pub struct AsyncStdListener {
+    listener: TcpListener,
+}
+
+pub fn block_on<F: core::future::Future>(future: F) -> F::Output {
+    task::block_on(future)
+}
+
+impl AsyncStdRuntime {
+    pub fn block_on<F: core::future::Future>(&self, future: F) -> F::Output {
+        task::block_on(future)
+    }
+}
+
+impl<T> TaskHandle<T> for AsyncStdTask<T>
+where
+    T: Send + 'static,
+{
+    async fn join(&mut self) -> Result<T, TaskJoinError> {
+        Ok((&mut self.handle).await)
+    }
+
+    fn abort(&self) {}
+
+    fn is_finished(&self) -> bool {
+        false
+    }
+}
+
+impl<T> ChannelSender<T> for AsyncStdSender<T>
+where
+    T: Send + 'static,
+{
+    async fn send(&self, item: T) -> Result<(), ChannelError> {
+        self.inner.send(item).await.map_err(|_| ChannelError::Closed)
+    }
+
+    fn try_send(&self, item: T) -> Result<(), ChannelError> {
+        match self.inner.try_send(item) {
+            Ok(()) => Ok(()),
+            Err(async_std::channel::TrySendError::Full(_)) => Err(ChannelError::Full),
+            Err(async_std::channel::TrySendError::Closed(_)) => Err(ChannelError::Closed),
+        }
+    }
+}
+
+impl<T> ChannelReceiver<T> for AsyncStdReceiver<T>
+where
+    T: Send + 'static,
+{
+    async fn recv(&mut self) -> Result<T, ChannelError> {
+        self.inner.recv().await.map_err(|_| ChannelError::Closed)
+    }
+}
+
+impl AsyncRuntime for AsyncStdRuntime {
+    type Task<T> = AsyncStdTask<T> where T: Send + 'static;
+    type Sender<T> = AsyncStdSender<T> where T: Send + 'static;
+    type Receiver<T> = AsyncStdReceiver<T> where T: Send + 'static;
+
+    fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
+    where
+        F: core::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        AsyncStdTask {
+            handle: task::spawn(future),
+        }
+    }
+
+    fn channel<T>(&self, capacity: usize) -> (Self::Sender<T>, Self::Receiver<T>)
+    where
+        T: Send + 'static,
+    {
+        let (tx, rx) = async_std::channel::bounded(capacity);
+        (
+            AsyncStdSender { inner: tx },
+            AsyncStdReceiver { inner: rx },
+        )
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        task::sleep(duration).await;
+    }
+}
+
+impl AsyncStdSocket {
+    pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<(), NetError> {
+        self.read_timeout = timeout;
+        Ok(())
+    }
+
+    pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> Result<(), NetError> {
+        self.write_timeout = timeout;
+        Ok(())
+    }
+}
+
+impl AsyncSocket for AsyncStdSocket {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, NetError> {
+        match self.read_timeout {
+            Some(timeout) => async_std::future::timeout(timeout, self.stream.read(buf))
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.read(buf).await.map_err(map_io_error),
+        }
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, NetError> {
+        match self.write_timeout {
+            Some(timeout) => async_std::future::timeout(timeout, self.stream.write(buf))
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.write(buf).await.map_err(map_io_error),
+        }
+    }
+
+    async fn flush(&mut self) -> Result<(), NetError> {
+        match self.write_timeout {
+            Some(timeout) => async_std::future::timeout(timeout, self.stream.flush())
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.flush().await.map_err(map_io_error),
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), NetError> {
+        Ok(())
+    }
+}
+
+impl AsyncListener for AsyncStdListener {
+    type Socket = AsyncStdSocket;
+
+    async fn accept(&mut self) -> Result<Self::Socket, NetError> {
+        let (stream, _) = self.listener.accept().await.map_err(map_io_error)?;
+        Ok(AsyncStdSocket {
+            stream,
+            read_timeout: None,
+            write_timeout: None,
+        })
+    }
+
+    async fn close(&mut self) -> Result<(), NetError> {
+        Ok(())
+    }
+}
+
+impl AsyncNet for AsyncStdNet {
+    type Socket = AsyncStdSocket;
+    type Listener = AsyncStdListener;
+
+    async fn connect(&self, address: &str) -> Result<Self::Socket, NetError> {
+        let stream = TcpStream::connect(address).await.map_err(map_io_error)?;
+        Ok(AsyncStdSocket {
+            stream,
+            read_timeout: None,
+            write_timeout: None,
+        })
+    }
+
+    async fn bind(&self, address: &str) -> Result<Self::Listener, NetError> {
+        let listener = TcpListener::bind(address).await.map_err(map_io_error)?;
+        Ok(AsyncStdListener { listener })
+    }
+}
+
+fn map_io_error(error: std::io::Error) -> NetError {
+    use std::io::ErrorKind;
+
+    match error.kind() {
+        ErrorKind::BrokenPipe
+        | ErrorKind::ConnectionAborted
+        | ErrorKind::ConnectionReset
+        | ErrorKind::UnexpectedEof
+        | ErrorKind::NotConnected => NetError::Closed,
+        ErrorKind::TimedOut | ErrorKind::WouldBlock => NetError::TimedOut,
+        ErrorKind::AddrInUse
+        | ErrorKind::AddrNotAvailable
+        | ErrorKind::ConnectionRefused
+        | ErrorKind::HostUnreachable
+        | ErrorKind::NetworkUnreachable => NetError::Unreachable,
+        ErrorKind::Unsupported => NetError::Unsupported,
+        _ => NetError::Other("async-std io error"),
+    }
+}

--- a/crates/ferredge-runtime-async-std/src/lib.rs
+++ b/crates/ferredge-runtime-async-std/src/lib.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use async_std::{
     io::{ReadExt, WriteExt},
     net::{TcpListener, TcpStream},
+    sync::{Mutex, MutexGuard},
     task::{self, JoinHandle},
 };
 use ferredge_core::prelude::*;
@@ -23,6 +24,19 @@ pub struct AsyncStdSender<T> {
 
 pub struct AsyncStdReceiver<T> {
     inner: async_std::channel::Receiver<T>,
+}
+
+pub struct AsyncStdMutex<T> {
+    inner: Mutex<T>,
+}
+
+pub struct AsyncStdMutexGuard<'a, T> {
+    inner: MutexGuard<'a, T>,
+}
+
+#[derive(Clone)]
+pub struct AsyncStdInstant {
+    inner: std::time::Instant,
 }
 
 impl<T> Clone for AsyncStdSender<T> {
@@ -102,10 +116,55 @@ where
     }
 }
 
+impl<T> core::ops::Deref for AsyncStdMutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> core::ops::DerefMut for AsyncStdMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> AsyncMutex<T> for AsyncStdMutex<T>
+where
+    T: Send + 'static,
+{
+    type Guard<'a>
+        = AsyncStdMutexGuard<'a, T>
+    where
+        T: 'a;
+
+    async fn lock(&self) -> Result<Self::Guard<'_>, MutexError> {
+        Ok(AsyncStdMutexGuard {
+            inner: self.inner.lock().await,
+        })
+    }
+
+    fn try_lock(&self) -> Result<Self::Guard<'_>, MutexError> {
+        self.inner
+            .try_lock()
+            .map(|inner| AsyncStdMutexGuard { inner })
+            .ok_or(MutexError::Busy)
+    }
+}
+
+impl RuntimeInstant for AsyncStdInstant {
+    fn elapsed(&self) -> Duration {
+        self.inner.elapsed()
+    }
+}
+
 impl AsyncRuntime for AsyncStdRuntime {
     type Task<T> = AsyncStdTask<T> where T: Send + 'static;
     type Sender<T> = AsyncStdSender<T> where T: Send + 'static;
     type Receiver<T> = AsyncStdReceiver<T> where T: Send + 'static;
+    type Mutex<T> = AsyncStdMutex<T> where T: Send + 'static;
+    type Instant = AsyncStdInstant;
 
     fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
     where
@@ -126,6 +185,21 @@ impl AsyncRuntime for AsyncStdRuntime {
             AsyncStdSender { inner: tx },
             AsyncStdReceiver { inner: rx },
         )
+    }
+
+    fn mutex<T>(&self, value: T) -> Self::Mutex<T>
+    where
+        T: Send + 'static,
+    {
+        AsyncStdMutex {
+            inner: Mutex::new(value),
+        }
+    }
+
+    fn now(&self) -> Self::Instant {
+        AsyncStdInstant {
+            inner: std::time::Instant::now(),
+        }
     }
 
     async fn sleep(&self, duration: Duration) {

--- a/crates/ferredge-runtime-async-std/src/lib.rs
+++ b/crates/ferredge-runtime-async-std/src/lib.rs
@@ -87,7 +87,10 @@ where
     T: Send + 'static,
 {
     async fn send(&self, item: T) -> Result<(), ChannelError> {
-        self.inner.send(item).await.map_err(|_| ChannelError::Closed)
+        self.inner
+            .send(item)
+            .await
+            .map_err(|_| ChannelError::Closed)
     }
 
     fn try_send(&self, item: T) -> Result<(), ChannelError> {
@@ -160,10 +163,22 @@ impl RuntimeInstant for AsyncStdInstant {
 }
 
 impl AsyncRuntime for AsyncStdRuntime {
-    type Task<T> = AsyncStdTask<T> where T: Send + 'static;
-    type Sender<T> = AsyncStdSender<T> where T: Send + 'static;
-    type Receiver<T> = AsyncStdReceiver<T> where T: Send + 'static;
-    type Mutex<T> = AsyncStdMutex<T> where T: Send + 'static;
+    type Task<T>
+        = AsyncStdTask<T>
+    where
+        T: Send + 'static;
+    type Sender<T>
+        = AsyncStdSender<T>
+    where
+        T: Send + 'static;
+    type Receiver<T>
+        = AsyncStdReceiver<T>
+    where
+        T: Send + 'static;
+    type Mutex<T>
+        = AsyncStdMutex<T>
+    where
+        T: Send + 'static;
     type Instant = AsyncStdInstant;
 
     fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
@@ -181,10 +196,7 @@ impl AsyncRuntime for AsyncStdRuntime {
         T: Send + 'static,
     {
         let (tx, rx) = async_std::channel::bounded(capacity);
-        (
-            AsyncStdSender { inner: tx },
-            AsyncStdReceiver { inner: rx },
-        )
+        (AsyncStdSender { inner: tx }, AsyncStdReceiver { inner: rx })
     }
 
     fn mutex<T>(&self, value: T) -> Self::Mutex<T>

--- a/crates/ferredge-runtime-embassy/Cargo.toml
+++ b/crates/ferredge-runtime-embassy/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ferredge-runtime-embassy"
+description = "Embassy runtime adapter scaffold for ferredge core traits"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ferredge-core = { workspace = true }

--- a/crates/ferredge-runtime-embassy/src/lib.rs
+++ b/crates/ferredge-runtime-embassy/src/lib.rs
@@ -1,0 +1,11 @@
+//! Embassy adapter scaffold.
+//!
+//! Embassy uses a different executor and ownership model than std-first runtimes, so this crate
+//! is intentionally a scaffold for now. The core runtime and net traits already live in
+//! `ferredge-core`; this crate will host the embassy-specific implementations.
+
+#![no_std]
+
+pub struct EmbassyRuntime;
+
+pub struct EmbassyNet;

--- a/crates/ferredge-runtime-tokio/Cargo.toml
+++ b/crates/ferredge-runtime-tokio/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ferredge-runtime-tokio"
+description = "Tokio runtime and network adapters for ferredge core traits"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ferredge-core = { workspace = true, features = ["std"] }
+tokio = { workspace = true }

--- a/crates/ferredge-runtime-tokio/src/lib.rs
+++ b/crates/ferredge-runtime-tokio/src/lib.rs
@@ -117,6 +117,14 @@ where
     async fn recv(&mut self) -> Result<T, ChannelError> {
         self.inner.recv().await.ok_or(ChannelError::Closed)
     }
+
+    fn try_recv(&mut self) -> Result<T, ChannelError> {
+        match self.inner.try_recv() {
+            Ok(item) => Ok(item),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => Err(ChannelError::Empty),
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => Err(ChannelError::Closed),
+        }
+    }
 }
 
 impl AsyncRuntime for TokioRuntime {

--- a/crates/ferredge-runtime-tokio/src/lib.rs
+++ b/crates/ferredge-runtime-tokio/src/lib.rs
@@ -8,7 +8,7 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     runtime::{Handle, Runtime},
-    sync::mpsc,
+    sync::{Mutex, MutexGuard, mpsc},
     task::JoinHandle,
 };
 
@@ -30,6 +30,19 @@ pub struct TokioSender<T> {
 
 pub struct TokioReceiver<T> {
     inner: mpsc::Receiver<T>,
+}
+
+pub struct TokioMutex<T> {
+    inner: Mutex<T>,
+}
+
+pub struct TokioMutexGuard<'a, T> {
+    inner: MutexGuard<'a, T>,
+}
+
+#[derive(Clone)]
+pub struct TokioInstant {
+    inner: std::time::Instant,
 }
 
 impl<T> Clone for TokioSender<T> {
@@ -127,10 +140,55 @@ where
     }
 }
 
+impl<T> core::ops::Deref for TokioMutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> core::ops::DerefMut for TokioMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T> AsyncMutex<T> for TokioMutex<T>
+where
+    T: Send + 'static,
+{
+    type Guard<'a>
+        = TokioMutexGuard<'a, T>
+    where
+        T: 'a;
+
+    async fn lock(&self) -> Result<Self::Guard<'_>, MutexError> {
+        Ok(TokioMutexGuard {
+            inner: self.inner.lock().await,
+        })
+    }
+
+    fn try_lock(&self) -> Result<Self::Guard<'_>, MutexError> {
+        self.inner
+            .try_lock()
+            .map(|inner| TokioMutexGuard { inner })
+            .map_err(|_| MutexError::Busy)
+    }
+}
+
+impl RuntimeInstant for TokioInstant {
+    fn elapsed(&self) -> Duration {
+        self.inner.elapsed()
+    }
+}
+
 impl AsyncRuntime for TokioRuntime {
     type Task<T> = TokioTask<T> where T: Send + 'static;
     type Sender<T> = TokioSender<T> where T: Send + 'static;
     type Receiver<T> = TokioReceiver<T> where T: Send + 'static;
+    type Mutex<T> = TokioMutex<T> where T: Send + 'static;
+    type Instant = TokioInstant;
 
     fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
     where
@@ -148,6 +206,21 @@ impl AsyncRuntime for TokioRuntime {
     {
         let (tx, rx) = mpsc::channel(capacity);
         (TokioSender { inner: tx }, TokioReceiver { inner: rx })
+    }
+
+    fn mutex<T>(&self, value: T) -> Self::Mutex<T>
+    where
+        T: Send + 'static,
+    {
+        TokioMutex {
+            inner: Mutex::new(value),
+        }
+    }
+
+    fn now(&self) -> Self::Instant {
+        TokioInstant {
+            inner: std::time::Instant::now(),
+        }
     }
 
     async fn sleep(&self, duration: Duration) {

--- a/crates/ferredge-runtime-tokio/src/lib.rs
+++ b/crates/ferredge-runtime-tokio/src/lib.rs
@@ -1,0 +1,252 @@
+use std::{
+    sync::Arc,
+    time::Duration,
+};
+
+use ferredge_core::prelude::*;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    runtime::{Handle, Runtime},
+    sync::mpsc,
+    task::JoinHandle,
+};
+
+#[derive(Clone)]
+pub struct TokioRuntime {
+    runtime: Arc<Runtime>,
+}
+
+#[derive(Clone, Default)]
+pub struct TokioNet;
+
+pub struct TokioTask<T> {
+    handle: JoinHandle<T>,
+}
+
+pub struct TokioSender<T> {
+    inner: mpsc::Sender<T>,
+}
+
+pub struct TokioReceiver<T> {
+    inner: mpsc::Receiver<T>,
+}
+
+impl<T> Clone for TokioSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct TokioSocket {
+    stream: TcpStream,
+    read_timeout: Option<Duration>,
+    write_timeout: Option<Duration>,
+}
+
+pub struct TokioListener {
+    listener: TcpListener,
+}
+
+impl Default for TokioRuntime {
+    fn default() -> Self {
+        Self {
+            runtime: Arc::new(
+                Runtime::new().expect("tokio runtime should initialize for ferredge adapter"),
+            ),
+        }
+    }
+}
+
+impl TokioRuntime {
+    pub fn block_on<F: core::future::Future>(&self, future: F) -> F::Output {
+        if Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| Handle::current().block_on(future))
+        } else {
+            self.runtime.block_on(future)
+        }
+    }
+}
+
+pub fn block_on<F: core::future::Future>(future: F) -> F::Output {
+    TokioRuntime::default().block_on(future)
+}
+
+impl<T> TaskHandle<T> for TokioTask<T>
+where
+    T: Send + 'static,
+{
+    async fn join(&mut self) -> Result<T, TaskJoinError> {
+        (&mut self.handle)
+            .await
+            .map_err(|_| TaskJoinError::Cancelled)
+    }
+
+    fn abort(&self) {
+        self.handle.abort();
+    }
+
+    fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
+}
+
+impl<T> ChannelSender<T> for TokioSender<T>
+where
+    T: Send + 'static,
+{
+    async fn send(&self, item: T) -> Result<(), ChannelError> {
+        self.inner.send(item).await.map_err(|_| ChannelError::Closed)
+    }
+
+    fn try_send(&self, item: T) -> Result<(), ChannelError> {
+        match self.inner.try_send(item) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(ChannelError::Full),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(ChannelError::Closed),
+        }
+    }
+}
+
+impl<T> ChannelReceiver<T> for TokioReceiver<T>
+where
+    T: Send + 'static,
+{
+    async fn recv(&mut self) -> Result<T, ChannelError> {
+        self.inner.recv().await.ok_or(ChannelError::Closed)
+    }
+}
+
+impl AsyncRuntime for TokioRuntime {
+    type Task<T> = TokioTask<T> where T: Send + 'static;
+    type Sender<T> = TokioSender<T> where T: Send + 'static;
+    type Receiver<T> = TokioReceiver<T> where T: Send + 'static;
+
+    fn spawn<F>(&self, future: F) -> Self::Task<F::Output>
+    where
+        F: core::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        TokioTask {
+            handle: self.runtime.spawn(future),
+        }
+    }
+
+    fn channel<T>(&self, capacity: usize) -> (Self::Sender<T>, Self::Receiver<T>)
+    where
+        T: Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel(capacity);
+        (TokioSender { inner: tx }, TokioReceiver { inner: rx })
+    }
+
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
+    }
+}
+
+impl TokioSocket {
+    pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<(), NetError> {
+        self.read_timeout = timeout;
+        Ok(())
+    }
+
+    pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> Result<(), NetError> {
+        self.write_timeout = timeout;
+        Ok(())
+    }
+}
+
+impl AsyncSocket for TokioSocket {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, NetError> {
+        match self.read_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, self.stream.read(buf))
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.read(buf).await.map_err(map_io_error),
+        }
+    }
+
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, NetError> {
+        match self.write_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, self.stream.write(buf))
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.write(buf).await.map_err(map_io_error),
+        }
+    }
+
+    async fn flush(&mut self) -> Result<(), NetError> {
+        match self.write_timeout {
+            Some(timeout) => tokio::time::timeout(timeout, self.stream.flush())
+                .await
+                .map_err(|_| NetError::TimedOut)?
+                .map_err(map_io_error),
+            None => self.stream.flush().await.map_err(map_io_error),
+        }
+    }
+
+    async fn close(&mut self) -> Result<(), NetError> {
+        self.stream.shutdown().await.map_err(map_io_error)
+    }
+}
+
+impl AsyncListener for TokioListener {
+    type Socket = TokioSocket;
+
+    async fn accept(&mut self) -> Result<Self::Socket, NetError> {
+        let (stream, _) = self.listener.accept().await.map_err(map_io_error)?;
+        Ok(TokioSocket {
+            stream,
+            read_timeout: None,
+            write_timeout: None,
+        })
+    }
+
+    async fn close(&mut self) -> Result<(), NetError> {
+        Ok(())
+    }
+}
+
+impl AsyncNet for TokioNet {
+    type Socket = TokioSocket;
+    type Listener = TokioListener;
+
+    async fn connect(&self, address: &str) -> Result<Self::Socket, NetError> {
+        let stream = TcpStream::connect(address).await.map_err(map_io_error)?;
+        Ok(TokioSocket {
+            stream,
+            read_timeout: None,
+            write_timeout: None,
+        })
+    }
+
+    async fn bind(&self, address: &str) -> Result<Self::Listener, NetError> {
+        let listener = TcpListener::bind(address).await.map_err(map_io_error)?;
+        Ok(TokioListener { listener })
+    }
+}
+
+fn map_io_error(error: std::io::Error) -> NetError {
+    use std::io::ErrorKind;
+
+    match error.kind() {
+        ErrorKind::BrokenPipe
+        | ErrorKind::ConnectionAborted
+        | ErrorKind::ConnectionReset
+        | ErrorKind::UnexpectedEof
+        | ErrorKind::NotConnected => NetError::Closed,
+        ErrorKind::TimedOut | ErrorKind::WouldBlock => NetError::TimedOut,
+        ErrorKind::AddrInUse
+        | ErrorKind::AddrNotAvailable
+        | ErrorKind::ConnectionRefused
+        | ErrorKind::HostUnreachable
+        | ErrorKind::NetworkUnreachable => NetError::Unreachable,
+        ErrorKind::Unsupported => NetError::Unsupported,
+        _ => NetError::Other("tokio io error"),
+    }
+}

--- a/crates/ferredge-runtime-tokio/src/lib.rs
+++ b/crates/ferredge-runtime-tokio/src/lib.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use ferredge_core::prelude::*;
 use tokio::{
@@ -111,7 +108,10 @@ where
     T: Send + 'static,
 {
     async fn send(&self, item: T) -> Result<(), ChannelError> {
-        self.inner.send(item).await.map_err(|_| ChannelError::Closed)
+        self.inner
+            .send(item)
+            .await
+            .map_err(|_| ChannelError::Closed)
     }
 
     fn try_send(&self, item: T) -> Result<(), ChannelError> {
@@ -184,10 +184,22 @@ impl RuntimeInstant for TokioInstant {
 }
 
 impl AsyncRuntime for TokioRuntime {
-    type Task<T> = TokioTask<T> where T: Send + 'static;
-    type Sender<T> = TokioSender<T> where T: Send + 'static;
-    type Receiver<T> = TokioReceiver<T> where T: Send + 'static;
-    type Mutex<T> = TokioMutex<T> where T: Send + 'static;
+    type Task<T>
+        = TokioTask<T>
+    where
+        T: Send + 'static;
+    type Sender<T>
+        = TokioSender<T>
+    where
+        T: Send + 'static;
+    type Receiver<T>
+        = TokioReceiver<T>
+    where
+        T: Send + 'static;
+    type Mutex<T>
+        = TokioMutex<T>
+    where
+        T: Send + 'static;
     type Instant = TokioInstant;
 
     fn spawn<F>(&self, future: F) -> Self::Task<F::Output>


### PR DESCRIPTION
- Support most of v3 and v5 client API
- Updated core traits for compatibility
- v5 Response topic supported (note: no RPC pattern autosubscribe etc. ). Might be security risk.
- Async runtime adapters
- `no_std` support

Fixes: #6